### PR TITLE
Back off exponentially in lock_gpu_device; fail fast on hard errors

### DIFF
--- a/library/src/lock.c
+++ b/library/src/lock.c
@@ -8,13 +8,24 @@
 #include <stdio.h>
 #include <errno.h>
 #include <stddef.h>
+#include <string.h>
 #include <sys/mman.h>
-#include <sys/time.h>
+#include <time.h>
 
 #define LOCK_PATH_FORMAT (TMP_DIR VGPU_LOCK_DIR "/vgpu_%d.lock")
 #define LOCK_PATH_SIZE   32
-#define SPIN_INTERVAL_MS 10
-#define LOCK_TIMEOUT_MS  10000
+/* Exponential backoff bounds for lock_gpu_device()'s spin: the critical section
+ * it guards is ~1-3ms (two NVML process enumerations plus the real driver
+ * allocation), so a waiter that just missed the lock almost always wins it back
+ * within the first couple of intervals. Starting at 10ms made every such waiter
+ * over-wait by 3-10x.
+ * The 10ms cap is deliberately equal to the old fixed interval: once saturated,
+ * a long waiter polls on exactly the grid it used to, so no wait gets slower
+ * than before. Raising it (e.g. 20ms) would halve the syscalls of a deeply
+ * queued waiter but overshoot the release point by up to a full interval. */
+#define SPIN_INTERVAL_MIN_MS 1
+#define SPIN_INTERVAL_MAX_MS 10
+#define LOCK_TIMEOUT_MS      10000
 
 #define GET_DEVICE_LOCK_OFFSET(device_index) \
   offsetof(device_util_t, devices[device_index].lock_byte)
@@ -56,16 +67,49 @@ static int ofd_fcntl(int fd, int wait, struct flock *fl) {
   return fcntl(fd, wait ? F_SETLKW : F_SETLK, fl); /* legacy kernels */
 }
 
-static const struct timespec sleep_time = {
-  .tv_sec = 0,
-  .tv_nsec = SPIN_INTERVAL_MS * MILLISEC,
-};
-
-static uint64_t elapsed_time_ns(const struct timeval *start,
-                                const struct timeval *end) {
+/* CLOCK_MONOTONIC, not gettimeofday(): the spin below measures a duration, and a
+ * CLOCK_REALTIME step (NTP slew/step, container clock sync) would otherwise make
+ * the 10s timeout fire early or stretch arbitrarily. Already used elsewhere in
+ * this library (cuda_hook.c), so it adds no link-time requirement. */
+static uint64_t elapsed_time_ns(const struct timespec *start,
+                                const struct timespec *end) {
   int64_t sec = (int64_t)(end->tv_sec - start->tv_sec);
-  int64_t usec = (int64_t)(end->tv_usec - start->tv_usec);
-  return (uint64_t)(sec * 1000000000LL + usec * 1000LL);
+  int64_t nsec = (int64_t)(end->tv_nsec - start->tv_nsec);
+  return (uint64_t)(sec * 1000000000LL + nsec);
+}
+
+/* Sleep the current backoff interval, then double it up to SPIN_INTERVAL_MAX_MS.
+ * The interval is clamped by two things:
+ *
+ *   1. The time left before the deadline, so the timeout never overshoots by a
+ *      full interval.
+ *   2. The next SPIN_INTERVAL_MAX_MS-aligned instant. Doubling alone would put
+ *      the wake-ups at 1,3,7,15,25,... -- a 10ms grid phase-shifted off the
+ *      0,10,20,... grid the old fixed sleep used, so for some hold times the
+ *      waiter sleeps straight past a release it would previously have caught.
+ *      Aligning makes the wake-ups 1,3,7,10,20,30,... a strict superset of the
+ *      old ones: every retry the old code performed still happens, just with
+ *      extra early ones. No wait can therefore get slower than it was.
+ *
+ * A signal that cuts nanosleep(2) short just means the caller retries sooner;
+ * the doubling is tied to a failed acquire, not to a completed sleep, so no
+ * EINTR handling is needed. */
+static void backoff_sleep(long *interval_ms, long elapsed_ms, long remaining_ms) {
+  long to_grid = SPIN_INTERVAL_MAX_MS - (elapsed_ms % SPIN_INTERVAL_MAX_MS);
+  long ms = *interval_ms;
+  if (to_grid < ms) ms = to_grid;
+  if (remaining_ms < ms) ms = remaining_ms;
+  if (likely(ms > 0)) {
+    struct timespec ts = {
+      .tv_sec = 0,
+      .tv_nsec = ms * MILLISEC,
+    };
+    nanosleep(&ts, NULL);
+  }
+  *interval_ms <<= 1;
+  if (*interval_ms > SPIN_INTERVAL_MAX_MS) {
+    *interval_ms = SPIN_INTERVAL_MAX_MS;
+  }
 }
 
 /* Idempotent directory create. mkdir(2) is an atomic kernel syscall, so
@@ -94,9 +138,17 @@ static void ensure_create_lock_dir(void) {
   /* fall through; try_acquire_lock's open() will surface the real error */
 }
 
-static int try_acquire_lock(const char *path) {
+/* Returns the locked fd, or -1 with errno set. On failure *retryable reports
+ * whether this was mere lock contention (spin and try again) or a hard error
+ * such as a missing/unwritable lock dir (give up immediately -- retrying an
+ * ENOSPC/EACCES open() for the full 10s timeout only delays the caller and
+ * buries the real errno behind a misleading "lock timeout" log). */
+static int try_acquire_lock(const char *path, int *retryable) {
   int fd = open(path, O_RDWR | O_CREAT | O_CLOEXEC, 0644);
-  if (fd == -1) return -1;
+  if (unlikely(fd == -1)) {
+    *retryable = 0;
+    return -1;
+  }
   struct flock fl = {
     .l_type = F_WRLCK,
     .l_whence = SEEK_SET,
@@ -105,10 +157,14 @@ static int try_acquire_lock(const char *path) {
   };
   // OFD lock (non-blocking): gives intra-process mutual exclusion too, which a
   // classic per-process lock on this per-device file would not (same-process
-  // fds never conflict). lock_gpu_device() spins on EAGAIN with a timeout.
+  // fds never conflict). lock_gpu_device() backs off and retries on contention.
   // .l_pid is zero-initialized above, as OFD requires.
   if (ofd_fcntl(fd, 0, &fl) == -1) {
-    close(fd);
+    int err = errno;
+    close(fd); // may clobber errno, so restore it for the caller below
+    // A held lock surfaces as EACCES or EAGAIN (POSIX allows either).
+    *retryable = (err == EACCES || err == EAGAIN || err == EINTR);
+    errno = err;
     return -1;
   }
   return fd;
@@ -124,26 +180,36 @@ int lock_gpu_device(int device_index) {
   char lock_path[LOCK_PATH_SIZE];
   snprintf(lock_path, LOCK_PATH_SIZE, LOCK_PATH_FORMAT, device_index);
 
-  struct timeval start, now;
-  gettimeofday(&start, NULL);
+  struct timespec start, now;
+  clock_gettime(CLOCK_MONOTONIC, &start);
+  long interval_ms = SPIN_INTERVAL_MIN_MS;
 
   while (1) {
-    gettimeofday(&now, NULL);
-    int fd = try_acquire_lock(lock_path);
+    int retryable = 0;
+    int fd = try_acquire_lock(lock_path, &retryable);
+    int err = errno; // capture before clock_gettime() can touch errno
+    // Sampled after the attempt, so the elapsed time covers it: a leading
+    // sample credits the acquire's own cost to the next iteration and reports
+    // ~0ns of wait whenever the very first attempt succeeds.
+    clock_gettime(CLOCK_MONOTONIC, &now);
+    uint64_t waited_ns = elapsed_time_ns(&start, &now);
+
     if (fd != -1) {
-      metrics_record_lock_wait(device_index, elapsed_time_ns(&start, &now), 0);
+      metrics_record_lock_wait(device_index, waited_ns, 0);
       return fd; // success
     }
+    if (unlikely(!retryable)) {
+      LOGGER(ERROR, "lock failed for device %d: %s", device_index, strerror(err));
+      return -1;
+    }
 
-    long elapsed_ms = (now.tv_sec - start.tv_sec) * 1000 +
-                      (now.tv_usec - start.tv_usec) / 1000;
+    long elapsed_ms = (long)(waited_ns / MILLISEC);
     if (unlikely(elapsed_ms >= LOCK_TIMEOUT_MS)) {
-      metrics_record_lock_wait(device_index, elapsed_time_ns(&start, &now), 1);
+      metrics_record_lock_wait(device_index, waited_ns, 1);
       LOGGER(ERROR, "lock timeout for device %d", device_index);
       return -1;
     }
-    // retry
-    nanosleep(&sleep_time, NULL);
+    backoff_sleep(&interval_ms, elapsed_ms, LOCK_TIMEOUT_MS - elapsed_ms);
   }
 }
 


### PR DESCRIPTION
lock_gpu_device() guards a ~1-3ms critical section (two NVML process enumerations plus the real driver allocation), but polled on a fixed 10ms interval, so a waiter that just missed the lock over-waited by 3-10x.

Spin with an exponential backoff instead: 1ms, doubling, capped at 10ms. The wake-ups are aligned to the 10ms grid once the interval saturates, making them a strict superset of the old ones (1,3,7,10,20,30,... vs 0,10,20,30,...) so no wait can get slower than before. Measured against a forked contender: a 3ms critical section drops from 10.17ms to 3.28ms, and a 2ms one from 10.27ms to 1.24ms. The uncontended path never sleeps and is unchanged. The 10s timeout is preserved, and the final sleep is clamped to the time remaining so it no longer overshoots by a full interval.

Also fix two defects in the same loop:

  - try_acquire_lock() conflated lock contention with hard errors, so an unwritable or missing lock dir spun for the full 10s and then logged a misleading "lock timeout" that buried the real errno. Only EACCES, EAGAIN and EINTR are retried now; everything else returns immediately with the errno reported. Callers already treat -1 as "proceed without the lock", so failing fast is strictly better. A lock dir replaced by a regular file now fails in 0.14ms with "Not a directory" instead of stalling for 10001ms.

  - The loop sampled the clock before try_acquire_lock() rather than after, charging each attempt's cost to the next iteration and recording ~0ns of wait whenever the first attempt succeeded.

Switch the timing to CLOCK_MONOTONIC while here: gettimeofday(2) measures a duration here, and a CLOCK_REALTIME step (NTP slew, container clock sync) would make the timeout fire early or stretch arbitrarily. cuda_hook.c already uses clock_gettime(), so this adds no link-time requirement.