### PR TITLE
Fix hard-limit anti-jitter bypass pinning util near 0 on small-SM GPUs

### DIFF
--- a/library/src/cuda_hook.c
+++ b/library/src/cuda_hook.c
@@ -85,6 +85,17 @@ static pthread_once_t g_init_set = PTHREAD_ONCE_INIT;
 static volatile int64_t g_cur_cuda_cores[MAX_DEVICE_COUNT]   = {0};
 static volatile int64_t g_total_cuda_cores[MAX_DEVICE_COUNT] = {0};
 
+/* Set by rate_limiter() (any app thread) whenever it actually throttles a
+ * launch (bucket ran negative), read-and-cleared once per cycle by the watcher.
+ * Lets the watcher's hard-limit anti-jitter bypass tell "util is low because
+ * the workload is idle" (no throttle -> keep the clamp) from "util is low
+ * because the clamp is starving a workload that wants more" (throttled -> fall
+ * through to the accumulating path so the bucket recovers -- otherwise a
+ * small-SM GPU stays pinned near 0% util forever). Cross-thread, so accessed
+ * with __atomic; RELAXED suffices -- it is a plain demand flag with no ordering
+ * dependency on other state. */
+static int g_throttled_since_watch[MAX_DEVICE_COUNT] = {0};
+
 static int g_sm_num[MAX_DEVICE_COUNT]            = {0};
 static int g_max_thread_per_sm[MAX_DEVICE_COUNT] = {0};
 
@@ -489,7 +500,7 @@ dynamic_config_t g_dynamic_config = {
   .aimd_ai_base_div             = 400,
   .aimd_deadband_ratio          = 800,
   .aimd_md_cooldown_cycles      = 3,
-  .auto_debounce_cycles         = 5,
+  .auto_debounce_cycles         = 10,
   .auto_external_util_threshold = 1,
 };
 
@@ -524,6 +535,10 @@ static void rate_limiter(int grids, int blocks, int host_index) {
       before_cuda_cores = g_cur_cuda_cores[host_index];
       if (before_cuda_cores < 0) {
         metrics_record_rate_limit_hit(host_index);
+        /* Signal the watcher that this workload wanted more than its current
+         * bucket allowed -- this is genuine demand, not idleness. Slow path
+         * (we are about to sleep), so the atomic store is free. */
+        __atomic_store_n(&g_throttled_since_watch[host_index], 1, __ATOMIC_RELAXED);
         nanosleep(&g_cycle, NULL);
         goto CHECK;
       }
@@ -1078,14 +1093,30 @@ static void *utilization_watcher(void *arg) {
 
       sys_frees[host_index] = MAX_UTILIZATION - top_results[host_index].sys_current;
 
+      /* Read-and-clear once per cycle (before either branch, so it never goes
+       * stale): did any launch on this device throttle since we last looked? */
+      int throttled = __atomic_exchange_n(&g_throttled_since_watch[host_index], 0, __ATOMIC_RELAXED);
+
       if (g_vgpu_config->devices[host_index].hard_limit) {
-        /* Avoid usage jitter when application is initialized. Use the RAW
-         * predicate (no debounce) here: this bypass must respond instantly
-         * to a freshly-started workload's util ramp, and the hard_limit
-         * controller cannot exceed hard_core anyway so a misfire here is
-         * not a safety hazard (worst case: a few cycles of slightly
-         * different share computation). */
-        if (host_index_is_exclusive_raw(host_index) && top_results[host_index].user_current < up_limits[host_index] / 10) {
+        /* Anti-jitter soft-start. Use the RAW predicate (no debounce) here: this
+         * bypass must respond instantly to a freshly-started workload's util
+         * ramp, and the hard_limit controller cannot exceed hard_core anyway so
+         * a misfire here is not a safety hazard (worst case: a few cycles of
+         * slightly different share computation).
+         *
+         * The bypass SETs g_cur to a single controller step and freezes shares[]
+         * (via continue, skipping change_token) so the bucket does NOT
+         * pre-accumulate to a full g_total during an idle/model-load phase --
+         * otherwise the first heavy kernels would burst from a full bucket to
+         * ~100% and get cut, causing startup jitter. But gate it on `!throttled`:
+         * if the workload is actually hitting the throttle, its low util is
+         * starvation, not idleness, and clamping would pin it near zero forever
+         * (fatal on small-SM GPUs where the sm^2-scaled clamp is a fraction of a
+         * percent -- observed util stuck <1%). In that case fall through to the
+         * accumulating path so the bucket ramps up to serve the demand. */
+        if (host_index_is_exclusive_raw(host_index)
+            && top_results[host_index].user_current < up_limits[host_index] / 10
+            && !throttled) {
           g_cur_cuda_cores[host_index] =
               g_sm_controller(g_vgpu_config->devices[host_index].hard_core, top_results[host_index].user_current, shares[host_index], host_index);
           continue;
@@ -1151,6 +1182,10 @@ static void *utilization_watcher(void *arg) {
              * AND we previously climbed past hard_core, give some back. */
             int avg = avg_sys_frees[host_index] * 2 / SOFT_ADJUST_INTERVAL;
             int step = g_vgpu_config->devices[host_index].hard_core / 10;
+            /* Integer division truncates to 0 for hard_core < 10, which would
+             * freeze up_limits (never climbs to soft_core, never steps back).
+             * Floor at 1 so the elastic ramp still moves for small limits. */
+            if (step < 1) step = 1;
             int soft = g_vgpu_config->devices[host_index].soft_core;
             int hard = g_vgpu_config->devices[host_index].hard_core;
             if (avg > g_dynamic_config.usage_threshold) {

--- a/library/src/util.c
+++ b/library/src/util.c
@@ -381,11 +381,12 @@ int get_aimd_ai_base_div(int *out) {
 }
 
 /* Number of consecutive observed-different watcher cycles required before
- * the "auto" mode flips between delta and aimd. Default 5 ~ 400ms, which
- * absorbs typical single-cycle NVML jitter in sys_process_num without
- * adding meaningful Pod start/exit latency (Pod start dominates anyway). */
+ * the "auto" mode flips between delta and aimd. Default 10 ~ 800ms, which
+ * absorbs multi-cycle NVML jitter in sys_process_num (the extra margin over
+ * the old 5 further suppresses exclusivity flapping) without adding meaningful
+ * Pod start/exit latency (Pod start dominates anyway). */
 int get_sm_auto_debounce_cycles(int *out) {
-  return get_positive_int_env(CUDA_SM_AUTO_DEBOUNCE_CYCLES_ENV, 5, out);
+  return get_positive_int_env(CUDA_SM_AUTO_DEBOUNCE_CYCLES_ENV, 10, out);
 }
 
 /* External-utilization threshold (percent) for the "is_exclusive" predicate


### PR DESCRIPTION
The watcher's hard-limit anti-jitter bypass clamps g_cur to a single controller step and freezes shares[] (SET + continue, skipping change_token) whenever the workload is exclusive and running below hard_core/10, so the token bucket does not pre-accumulate to a full g_total during an idle/model-load phase and burst to ~100% on the first heavy kernels.

That clamp value is delta()'s sm^2-scaled increment, which as a fraction of the full bucket is ~sm/1408. Below ~42 SMs (small GPUs, MIG slices) it sits under the hard_core/10 escape threshold, so the workload can never produce enough util to leave the bypass -- and because shares[] is frozen there, the bucket can never grow. Any workload whose demand exceeds the tiny clamp is pinned near 0% util forever. Observed on a ~7-SM slice under hard_core=30: util stuck at 0-1%, share collapsed to ~1e3 against a multi-million g_total. Large datacenter GPUs (>=76 SM, the only ones this path was validated on) clear the threshold at 5-9% and so never showed it.

Gate the clamp on a new per-device throttle flag. rate_limiter() sets g_throttled_since_watch[] (relaxed atomic, slow path) whenever it actually throttles a launch; the watcher reads-and-clears it once per cycle. Low util with no throttle is idleness -> keep the clamp (anti-jitter preserved). Low util while throttling is starvation -> fall through to the accumulating path so the bucket ramps up to serve the demand. The flag is a pure edge signal guarding no other state, so relaxed ordering is sufficient; it adds no lock, so no fork or deadlock hazard, and both watcher branches still drive g_cur >= 0 so rate_limiter's wait always releases. The bypass threshold is deliberately left unfloored: for hard_core < 10 it truncates to 0, which simply disables the bypass (pure accumulate, which is correct), so small limits need no special case.

Also fix an unrelated small-value truncation in the soft path: step = hard_core/10 becomes 0 for hard_core < 10, freezing the elastic up_limits ramp. Floor it at 1.

Raise auto_debounce_cycles 5 -> 10 (struct default and the env default in util.c, which overrides it) to further damp exclusivity-FSM flapping.

Compiles clean in both stream configs; runtime behaviour still needs on-GPU validation (LOGGER_LEVEL=5: watch curr core / share / util ramp on a small slice).