### PR TITLE
fix: Stricter GPU memory limitations to prevent over allocation during graphics capture

### DIFF
--- a/charts/vgpu-manager/templates/device-plugin/daemonset.yaml
+++ b/charts/vgpu-manager/templates/device-plugin/daemonset.yaml
@@ -259,12 +259,15 @@ spec:
         - name: kubelet-root
           hostPath:
             path: {{ (default "/var/lib/kubelet" .Values.devicePlugin.kubeletRoot) | trimSuffix "/" }}
+            type: Directory
         - name: device-plugins
           hostPath:
             path: {{ (default "/var/lib/kubelet" .Values.devicePlugin.kubeletRoot) | trimSuffix "/" }}/device-plugins
+            type: Directory
         - name: pod-resources
           hostPath:
             path: {{ (default "/var/lib/kubelet" .Values.devicePlugin.kubeletRoot) | trimSuffix "/" }}/pod-resources
+            type: Directory
         - name: manager-root
           hostPath:
             path: {{ $managerRoot | quote }}
@@ -281,6 +284,7 @@ spec:
         - name: driver-root
           hostPath:
             path: {{ $hostDriverRoot | quote }}
+            type: Directory
         {{- if or $nc.yaml $nc.json }}
         - name: node-config
           configMap:

--- a/cmd/device-plugin/main.go
+++ b/cmd/device-plugin/main.go
@@ -83,6 +83,9 @@ func runApp(opt *options.Options) (exitCode int) {
 		node.WithIMEXOption(opt.ImexChannelIDs, opt.ImexRequired),
 		node.WithDriverRootOption(driverRoot),
 		node.WithHostDriverRootOption(hostDriverRoot),
+		// If nvidiaDevRoot (the path to the device nodes on the host) is not set,
+		// we default to using the driver root on the host.
+		node.WithHostDevRootOption(hostDriverRoot),
 		node.WithCheckFieldsOption(true))
 	if err != nil {
 		klog.Errorf("Initialization of node config failed: %v", err)

--- a/library/hack/check_cuda_hook_consistency.py
+++ b/library/hack/check_cuda_hook_consistency.py
@@ -65,6 +65,7 @@ ABI_CONFLICT_FAMILIES = {
     "cuGraphAddDependencies":        ("cuGraphAddDependencies",          "cuGraphAddDependencies_v2"),
     "cuGraphRemoveDependencies":     ("cuGraphRemoveDependencies",       "cuGraphRemoveDependencies_v2"),
     "cuGraphAddNode":                ("cuGraphAddNode",                  "cuGraphAddNode_v2"),
+    "cuStreamGetCaptureInfo":        ("cuStreamGetCaptureInfo_v2",       "cuStreamGetCaptureInfo_v3"),
     # cuGetProcAddress is handled inline in cuGetProcAddress() and
     # cuGetProcAddress_v2() rather than via is_abi_conflict_base(), so
     # it is intentionally NOT in this table.

--- a/library/hack/check_exported_symbols.sh
+++ b/library/hack/check_exported_symbols.sh
@@ -44,6 +44,7 @@ FAMILIES=(
   "cuGraphRemoveDependencies     cuGraphRemoveDependencies      cuGraphRemoveDependencies_v2"
   "cuGraphAddNode                cuGraphAddNode                 cuGraphAddNode_v2"
   "cuGetProcAddress              cuGetProcAddress               cuGetProcAddress_v2"
+  "cuStreamGetCaptureInfo        cuStreamGetCaptureInfo_v2      cuStreamGetCaptureInfo_v3"
   # cuGetProcAddress above is listed for export-completeness (we must
   # export both ABI versions of this symbol) even though its substitution
   # logic is handled specially inside cuGetProcAddress() / _v2() in
@@ -116,6 +117,7 @@ FORBIDDEN_HELPERS=(
   formatUuid
   accumulate_used_memory
   cleanup_vmem_nodes
+  check_cleanup_vmem_nodes_by_device
   device_util_read_lock
   device_util_write_lock
   device_util_unlock
@@ -138,6 +140,7 @@ FORBIDDEN_HELPERS=(
   get_compatibility_mode
   get_used_gpu_memory_by_device
   get_used_gpu_virt_memory
+  get_gpu_virt_memory_type
   malloc_gpu_virt_memory
   free_gpu_virt_memory
   print_global_vgpu_config

--- a/library/hack/check_exported_symbols.sh
+++ b/library/hack/check_exported_symbols.sh
@@ -142,7 +142,9 @@ FORBIDDEN_HELPERS=(
   get_used_gpu_virt_memory
   get_gpu_virt_memory_type
   malloc_gpu_virt_memory
+  malloc_gpu_virt_memory_captured
   free_gpu_virt_memory
+  free_gpu_virt_memory_by_graph
   print_global_vgpu_config
   # Internal data tables shared between cuda_hook.c / nvml_hook.c / loader.c
   # via extern declarations. They must be linker-global at static-link time

--- a/library/include/cuda-helper.h
+++ b/library/include/cuda-helper.h
@@ -1011,9 +1011,9 @@ typedef enum {
   /** cuStreamBeginCapture_v2_ptsz */
 //  CUDA_ENTRY_ENUM(cuStreamBeginCapture_v2_ptsz),
   /** cuStreamGetCaptureInfo */
-//  CUDA_ENTRY_ENUM(cuStreamGetCaptureInfo),
+  CUDA_ENTRY_ENUM(cuStreamGetCaptureInfo),
   /** cuStreamGetCaptureInfo_ptsz */
-//  CUDA_ENTRY_ENUM(cuStreamGetCaptureInfo_ptsz),
+  CUDA_ENTRY_ENUM(cuStreamGetCaptureInfo_ptsz),
   /** cuThreadExchangeStreamCaptureMode */
   CUDA_ENTRY_ENUM(cuThreadExchangeStreamCaptureMode),
   /** cuDeviceGetNvSciSyncAttributes */
@@ -1209,8 +1209,10 @@ typedef enum {
   CUDA_ENTRY_ENUM(cuGraphMemFreeNodeGetParams),
   CUDA_ENTRY_ENUM(cuGraphReleaseUserObject),
   CUDA_ENTRY_ENUM(cuGraphRetainUserObject),
-//  CUDA_ENTRY_ENUM(cuStreamGetCaptureInfo_v2),
-//  CUDA_ENTRY_ENUM(cuStreamGetCaptureInfo_v2_ptsz),
+  CUDA_ENTRY_ENUM(cuStreamGetCaptureInfo_v2),
+  CUDA_ENTRY_ENUM(cuStreamGetCaptureInfo_v2_ptsz),
+  CUDA_ENTRY_ENUM(cuStreamGetCaptureInfo_v3),
+  CUDA_ENTRY_ENUM(cuStreamGetCaptureInfo_v3_ptsz),
   CUDA_ENTRY_ENUM(cuStreamUpdateCaptureDependencies),
   CUDA_ENTRY_ENUM(cuStreamUpdateCaptureDependencies_ptsz),
   CUDA_ENTRY_ENUM(cuUserObjectCreate),
@@ -1327,6 +1329,7 @@ static inline int is_abi_conflict_base(const char *sym) {
     "cuGraphAddDependencies",
     "cuGraphRemoveDependencies",
     "cuGraphAddNode",
+    "cuStreamGetCaptureInfo",
     /*
      * Note: cuGetProcAddress is intentionally NOT listed here even though
      * its unversioned form also has cross-major ABI drift (v1 4-arg vs _v2

--- a/library/include/cuda-helper.h
+++ b/library/include/cuda-helper.h
@@ -985,10 +985,10 @@ typedef enum {
 //  CUDA_ENTRY_ENUM(cuStreamBeginCapture),
 //  /** cuStreamBeginCapture_ptsz */
 //  CUDA_ENTRY_ENUM(cuStreamBeginCapture_ptsz),
-//  /** cuStreamEndCapture */
-//  CUDA_ENTRY_ENUM(cuStreamEndCapture),
-//  /** cuStreamEndCapture_ptsz */
-//  CUDA_ENTRY_ENUM(cuStreamEndCapture_ptsz),
+  /** cuStreamEndCapture */
+  CUDA_ENTRY_ENUM(cuStreamEndCapture),
+  /** cuStreamEndCapture_ptsz */
+  CUDA_ENTRY_ENUM(cuStreamEndCapture_ptsz),
   /** cuStreamGetCtx */
   CUDA_ENTRY_ENUM(cuStreamGetCtx),
   CUDA_ENTRY_ENUM(cuStreamGetCtx_v2),

--- a/library/include/hook.h
+++ b/library/include/hook.h
@@ -303,12 +303,25 @@ typedef struct {
   device_process_t devices[MAX_DEVICE_COUNT];
 } device_util_t;
 
+/* memory_node_t.type -- what a virtual-memory record stands for, and therefore
+ * how cuMemFreeAsync must retire it (see cuda_hook.c).
+ *
+ * UVA_SYNC / UVA_ASYNC name memory the oversold path handed out as managed
+ * memory; only UVA_ASYNC has to drain the stream and fall back to cuMemFree.
+ * CAPTURE and ASYNC_BRIDGE both name ordinary device memory that is merely
+ * being ACCOUNTED for, and differ in lifetime: a CAPTURE record lives until the
+ * application frees the pointer, while an ASYNC_BRIDGE record only covers the
+ * window between the driver call and the stream synchronize that makes the
+ * allocation visible to NVML -- the allocating hook retires it itself. */
+#define MEMORY_TYPE_UVA_SYNC     1
+#define MEMORY_TYPE_UVA_ASYNC    2
+#define MEMORY_TYPE_CAPTURE      3
+#define MEMORY_TYPE_ASYNC_BRIDGE 4
+
 typedef struct {
   CUdeviceptr dptr;
   size_t bytes;
-  // 1: Synchronize UVA memory records
-  // 2: Asynchronous UVA memory recording
-  // 3: Asynchronous memory recording
+  /* One of MEMORY_TYPE_* above. */
   int type;
   struct list_head node;
 } memory_node_t;

--- a/library/include/hook.h
+++ b/library/include/hook.h
@@ -308,11 +308,18 @@ typedef struct {
  *
  * UVA_SYNC / UVA_ASYNC name memory the oversold path handed out as managed
  * memory; only UVA_ASYNC has to drain the stream and fall back to cuMemFree.
- * CAPTURE and ASYNC_BRIDGE both name ordinary device memory that is merely
- * being ACCOUNTED for, and differ in lifetime: a CAPTURE record lives until the
- * application frees the pointer, while an ASYNC_BRIDGE record only covers the
- * window between the driver call and the stream synchronize that makes the
- * allocation visible to NVML -- the allocating hook retires it itself. */
+ *
+ * CAPTURE and ASYNC_BRIDGE both name ordinary device memory that is only being
+ * ACCOUNTED for, and both exist for exactly one reason: to cover a window in
+ * which the allocation is invisible to NVML. They differ in which window.
+ *   ASYNC_BRIDGE spans the driver call to the stream synchronize.
+ *   CAPTURE spans the capture itself. During capture cuMemAllocAsync only
+ *     reserves an address -- no physical memory exists until the graph is
+ *     launched, from which point NVML reports the graph pool. The charge is
+ *     what makes several allocations inside one capture accumulate against the
+ *     limit, and cuStreamEndCapture retires it (see free_gpu_virt_memory_by_graph)
+ *     because holding it past the launch would double-count against NVML and
+ *     leak whenever the graph, rather than the application, owns the pointer. */
 #define MEMORY_TYPE_UVA_SYNC     1
 #define MEMORY_TYPE_UVA_ASYNC    2
 #define MEMORY_TYPE_CAPTURE      3
@@ -323,6 +330,15 @@ typedef struct {
   size_t bytes;
   /* One of MEMORY_TYPE_* above. */
   int type;
+  /* Owning graph, for MEMORY_TYPE_CAPTURE only; NULL otherwise. Records are
+   * only ever charged when this is known, so every charge can be retired at
+   * cuStreamEndCapture. */
+  CUgraph graph;
+  /* Device the record was charged against, or -1 if it was never charged.
+   * Retiring a capture charge must not depend on being able to ask the driver
+   * which device is current -- by then the context may be gone, and failing to
+   * discharge after the node is dropped would strand the charge forever. */
+  int host_index;
   struct list_head node;
 } memory_node_t;
 
@@ -461,7 +477,23 @@ void check_cleanup_vmem_nodes_by_device(int host_index);
 
 void malloc_gpu_virt_memory(CUdeviceptr dptr, size_t bytes, int type, int device_id);
 
+/**
+ * Record a graph-capture allocation. Same as malloc_gpu_virt_memory() with
+ * MEMORY_TYPE_CAPTURE, but ties the record to the capturing graph so
+ * free_gpu_virt_memory_by_graph() can retire it at cuStreamEndCapture.
+ */
+void malloc_gpu_virt_memory_captured(CUdeviceptr dptr, size_t bytes,
+                                     CUgraph graph, int device_id);
+
 void free_gpu_virt_memory(CUdeviceptr dptr, int device_id);
+
+/**
+ * Retire every capture record belonging to graph, discharging the shared
+ * counter for each. Called when the capture ends -- successfully or not.
+ * Each record carries the device it was charged against, so this needs no
+ * device argument and cannot be defeated by a missing current context.
+ */
+void free_gpu_virt_memory_by_graph(CUgraph graph);
 
 int get_gpu_virt_memory_type(CUdeviceptr dptr);
 

--- a/library/include/hook.h
+++ b/library/include/hook.h
@@ -306,6 +306,10 @@ typedef struct {
 typedef struct {
   CUdeviceptr dptr;
   size_t bytes;
+  // 1: Synchronize UVA memory records
+  // 2: Asynchronous UVA memory recording
+  // 3: Asynchronous memory recording
+  int type;
   struct list_head node;
 } memory_node_t;
 
@@ -440,15 +444,11 @@ void get_used_gpu_memory_by_device(void *, nvmlDevice_t);
  */
 void get_used_gpu_virt_memory(void *, int device_id);
 
-void malloc_gpu_virt_memory(CUdeviceptr dptr, size_t bytes, int device_id);
+void malloc_gpu_virt_memory(CUdeviceptr dptr, size_t bytes, int type, int device_id);
 
 void free_gpu_virt_memory(CUdeviceptr dptr, int device_id);
 
-/**
- * Reports whether dptr was allocated through the oversold UVA fallback
- * (cuMemAllocManaged) and therefore must be released with cuMemFree.
- */
-int is_gpu_virt_memory(CUdeviceptr dptr);
+int get_gpu_virt_memory_type(CUdeviceptr dptr);
 
 int get_nvml_device_index_by_cuda_device(CUdevice device);
 

--- a/library/include/hook.h
+++ b/library/include/hook.h
@@ -485,7 +485,7 @@ void malloc_gpu_virt_memory(CUdeviceptr dptr, size_t bytes, int type, int device
 void malloc_gpu_virt_memory_captured(CUdeviceptr dptr, size_t bytes,
                                      CUgraph graph, int device_id);
 
-void free_gpu_virt_memory(CUdeviceptr dptr, int device_id);
+void free_gpu_virt_memory(CUdeviceptr dptr);
 
 /**
  * Retire every capture record belonging to graph, discharging the shared

--- a/library/include/hook.h
+++ b/library/include/hook.h
@@ -457,6 +457,8 @@ void get_used_gpu_memory_by_device(void *, nvmlDevice_t);
  */
 void get_used_gpu_virt_memory(void *, int device_id);
 
+void check_cleanup_vmem_nodes_by_device(int host_index);
+
 void malloc_gpu_virt_memory(CUdeviceptr dptr, size_t bytes, int type, int device_id);
 
 void free_gpu_virt_memory(CUdeviceptr dptr, int device_id);

--- a/library/src/cuda_hook.c
+++ b/library/src/cuda_hook.c
@@ -457,6 +457,7 @@ CUresult cuMemFreeAsync(CUdeviceptr dptr, CUstream hStream);
 CUresult cuMemFreeAsync_ptsz(CUdeviceptr dptr, CUstream hStream);
 CUresult cuStreamEndCapture(CUstream hStream, CUgraph *phGraph);
 CUresult cuStreamEndCapture_ptsz(CUstream hStream, CUgraph *phGraph);
+CUresult cuGraphDestroy(CUgraph hGraph);
 
 entry_t cuda_hooks_entry[] = {
     {.name = "cuDriverGetVersion", .fn_ptr = cuDriverGetVersion},
@@ -509,6 +510,7 @@ entry_t cuda_hooks_entry[] = {
     {.name = "cuMemFreeAsync_ptsz", .fn_ptr = cuMemFreeAsync_ptsz},
     {.name = "cuStreamEndCapture", .fn_ptr = cuStreamEndCapture},
     {.name = "cuStreamEndCapture_ptsz", .fn_ptr = cuStreamEndCapture_ptsz},
+    {.name = "cuGraphDestroy", .fn_ptr = cuGraphDestroy},
 };
 
 const int cuda_hook_nums =
@@ -1453,13 +1455,24 @@ static int stream_is_capturing(CUstream stream, int ptsz) {
  * established. `ptsz` selects the entry-point family, for the same reason as in
  * stream_is_capturing().
  *
- * Only _v2 and _v3 report the graph; the original cuStreamGetCaptureInfo yields
- * a status and an id only, so a driver that exports nothing newer leaves us
- * unable to identify the capture. NULL is returned in that case, and the caller
- * MUST then decline to charge the allocation: a charge we cannot attribute to a
- * graph is a charge cuStreamEndCapture can never retire, which would accumulate
- * into a permanent overstatement of usage and eventually fail every allocation.
- * Losing the charge only costs accumulation within that one capture. */
+ * The graph IS available mid-capture: cuStreamGetCaptureInfo documents graph_out
+ * as "the graph being captured into ... while the capture sequence is in
+ * progress", and the documented way to splice a node into a running capture
+ * (get info -> cuGraphAddNode -> cuStreamUpdateCaptureDependencies) depends on
+ * exactly that. Only _v2 and _v3 report it; the original entry point yields a
+ * status and an id only, so a driver exporting nothing newer leaves the capture
+ * unidentifiable. NULL is returned then, and the caller MUST decline to charge
+ * the allocation: a charge that cannot be attributed to a graph is one
+ * cuStreamEndCapture can never retire, and a permanently overstated usage fails
+ * every later allocation. Losing the charge only costs accumulation within that
+ * one capture.
+ *
+ * The status is accepted as anything but NONE, though the API only guarantees
+ * graph_out for CU_STREAM_CAPTURE_STATUS_ACTIVE. That is deliberate: this handle
+ * is used purely as an identity key to match records and is never dereferenced,
+ * and a capture that has gone INVALIDATED still has to have its charge retired.
+ * Tightening this to ACTIVE would strand the charge of every capture that failed
+ * before its cuStreamEndCapture. */
 static CUgraph stream_capture_graph(CUstream stream, int ptsz) {
   CUstreamCaptureStatus cap = CU_STREAM_CAPTURE_STATUS_NONE;
   cuuint64_t id = 0;
@@ -2778,7 +2791,7 @@ ALLOCATED_TO_GPU:
       /* Switching from capture to synchronous operation, off the device lock. */
       CUDA_INTERNAL_CHECK(cuda_library_entry, __CUDA_API_PTSZ(cuStreamSynchronize), hStream);
       /* Release internal accounting only once NVML is guaranteed to see it. */
-      free_gpu_virt_memory(*dptr, host_index);
+      free_gpu_virt_memory(*dptr);
     } else {
       /* Charge the capture so that several allocations inside one capture
        * accumulate against the limit. Chargeable only while the owning graph is
@@ -2852,7 +2865,7 @@ ALLOCATED_TO_GPU:
       /* Switching from capture to synchronous operation, off the device lock. */
       CUDA_INTERNAL_CHECK(cuda_library_entry, cuStreamSynchronize_ptsz, hStream);
       /* Release internal accounting only once NVML is guaranteed to see it. */
-      free_gpu_virt_memory(*dptr, host_index);
+      free_gpu_virt_memory(*dptr);
     } else {
       /* Charge the capture so that several allocations inside one capture
        * accumulate against the limit. Chargeable only while the owning graph is
@@ -3863,7 +3876,7 @@ CALL:
       /* Switching from capture to synchronous operation, off the device lock. */
       CUDA_INTERNAL_CHECK(cuda_library_entry, __CUDA_API_PTSZ(cuStreamSynchronize), hStream);
       /* Release internal accounting only once NVML is guaranteed to see it. */
-      free_gpu_virt_memory(*dptr, host_index);
+      free_gpu_virt_memory(*dptr);
     } else {
       /* Charge the capture so that several allocations inside one capture
        * accumulate against the limit. Chargeable only while the owning graph is
@@ -3917,7 +3930,7 @@ CALL:
       /* Switching from capture to synchronous operation, off the device lock. */
       CUDA_INTERNAL_CHECK(cuda_library_entry, cuStreamSynchronize_ptsz, hStream);
       /* Release internal accounting only once NVML is guaranteed to see it. */
-      free_gpu_virt_memory(*dptr, host_index);
+      free_gpu_virt_memory(*dptr);
     } else {
       /* Charge the capture so that several allocations inside one capture
        * accumulate against the limit. Chargeable only while the owning graph is
@@ -3950,7 +3963,7 @@ CUresult _cuMemFree(CUdeviceptr dptr) {
     ret = CUDA_ERROR_NOT_FOUND;
   }
   if (likely(ret == CUDA_SUCCESS)) {
-    free_gpu_virt_memory(dptr, get_host_device_index_by_cuda_device(device));
+    free_gpu_virt_memory(dptr);
   }
 DONE:
   return ret;
@@ -4023,7 +4036,7 @@ CUresult cuMemFreeAsync(CUdeviceptr dptr, CUstream hStream) {
   ret = CUDA_ENTRY_CHECK(cuda_library_entry, __CUDA_API_PTSZ(cuMemFreeAsync), dptr, hStream);
   if (likely(ret == CUDA_SUCCESS)) {
     if (type != 0) {
-      free_gpu_virt_memory(dptr, get_host_device_index_by_cuda_device(device));
+      free_gpu_virt_memory(dptr);
     }
   }
 DONE:
@@ -4045,7 +4058,7 @@ CUresult cuMemFreeAsync_ptsz(CUdeviceptr dptr, CUstream hStream) {
   ret = CUDA_ENTRY_CHECK(cuda_library_entry, cuMemFreeAsync_ptsz, dptr, hStream);
   if (likely(ret == CUDA_SUCCESS)) {
     if (type != 0) {
-      free_gpu_virt_memory(dptr, get_host_device_index_by_cuda_device(device));
+      free_gpu_virt_memory(dptr);
     }
   }
 DONE:
@@ -4083,4 +4096,20 @@ CUresult cuStreamEndCapture(CUstream hStream, CUgraph *phGraph) {
 
 CUresult cuStreamEndCapture_ptsz(CUstream hStream, CUgraph *phGraph) {
   return end_capture_and_discharge(hStream, phGraph, 1);
+}
+
+/* Second, deterministic discharge point for capture charges.
+ *
+ * cuStreamEndCapture retires the normal case, but a capture that was
+ * invalidated may not report its graph any more, and CUDA offers no way to test
+ * whether a CUgraph is still alive -- handles are recycled and probing a
+ * destroyed one is undefined. Destruction, on the other hand, is something the
+ * application tells us, and it names the graph exactly. Discharging here as well
+ * is safe because free_gpu_virt_memory_by_graph() is idempotent: the normal path
+ * has already emptied the graph's records by the time it is destroyed, so this
+ * only ever fires for charges nothing else claimed. */
+CUresult cuGraphDestroy(CUgraph hGraph) {
+  CUresult ret = CUDA_ENTRY_CHECK(cuda_library_entry, cuGraphDestroy, hGraph);
+  free_gpu_virt_memory_by_graph(hGraph);
+  return ret;
 }

--- a/library/src/cuda_hook.c
+++ b/library/src/cuda_hook.c
@@ -2715,8 +2715,12 @@ ALLOCATED_TO_GPU:
     }
   } else if (ret == CUDA_SUCCESS) {
     if (!stream_is_capturing(hStream, __CUDA_API_IS_PTSZ)) {
+      // Internal bookkeeping before synchronization is completed
+      malloc_gpu_virt_memory(*dptr, bytesize, 3, host_index);
       // Switching from capture to synchronous operation
       CUDA_INTERNAL_CHECK(cuda_library_entry, __CUDA_API_PTSZ(cuStreamSynchronize), hStream);
+      // Release internal accounting after synchronization is completed
+      free_gpu_virt_memory(*dptr, host_index);
     } else {
       // Recorded as virtual memory count during capture
       malloc_gpu_virt_memory(*dptr, bytesize, 3, host_index);
@@ -2777,8 +2781,12 @@ ALLOCATED_TO_GPU:
     }
   } else if (ret == CUDA_SUCCESS) {
     if (!stream_is_capturing(hStream, 1)) {
+      // Internal bookkeeping before synchronization is completed
+      malloc_gpu_virt_memory(*dptr, bytesize, 3, host_index);
       // Switching from capture to synchronous operation
       CUDA_INTERNAL_CHECK(cuda_library_entry, cuStreamSynchronize_ptsz, hStream);
+      // Release internal accounting after synchronization is completed
+      free_gpu_virt_memory(*dptr, host_index);
     } else {
       // Recorded as virtual memory count during capture
       malloc_gpu_virt_memory(*dptr, bytesize, 3, host_index);
@@ -3776,8 +3784,12 @@ CALL:
   ret = CUDA_ENTRY_CHECK(cuda_library_entry, __CUDA_API_PTSZ(cuMemAllocFromPoolAsync), dptr, bytesize, pool, hStream);
   if (ret == CUDA_SUCCESS) {
     if (!stream_is_capturing(hStream, __CUDA_API_IS_PTSZ)) {
+      // Internal bookkeeping before synchronization is completed
+      malloc_gpu_virt_memory(*dptr, bytesize, 3, host_index);
       // Switching from capture to synchronous operation
       CUDA_INTERNAL_CHECK(cuda_library_entry, __CUDA_API_PTSZ(cuStreamSynchronize), hStream);
+      // Release internal accounting after synchronization is completed
+      free_gpu_virt_memory(*dptr, host_index);
     } else {
       // Recorded as virtual memory count during capture
       malloc_gpu_virt_memory(*dptr, bytesize, 3, host_index);
@@ -3817,8 +3829,12 @@ CALL:
   ret = CUDA_ENTRY_CHECK(cuda_library_entry, cuMemAllocFromPoolAsync_ptsz, dptr, bytesize, pool, hStream);
   if (ret == CUDA_SUCCESS) {
     if (!stream_is_capturing(hStream, 1)) {
+      // Internal bookkeeping before synchronization is completed
+      malloc_gpu_virt_memory(*dptr, bytesize, 3, host_index);
       // Switching from capture to synchronous operation
       CUDA_INTERNAL_CHECK(cuda_library_entry, cuStreamSynchronize_ptsz, hStream);
+      // Release internal accounting after synchronization is completed
+      free_gpu_virt_memory(*dptr, host_index);
     } else {
       // Recorded as virtual memory count during capture
       malloc_gpu_virt_memory(*dptr, bytesize, 3, host_index);
@@ -3910,7 +3926,7 @@ CUresult cuMemFreeAsync(CUdeviceptr dptr, CUstream hStream) {
   int type = get_gpu_virt_memory_type(dptr);
   if (type == 2) {
     // If the memory type is asynchronous UVA memory record, go this branch
-    return free_virt_memory_uva_on_stream(dptr, hStream, 1);
+    return free_virt_memory_uva_on_stream(dptr, hStream, __CUDA_API_IS_PTSZ);
   }
   ret = CUDA_INTERNAL_CHECK(cuda_library_entry, cuCtxGetDevice, &device);
   if (unlikely(ret != CUDA_SUCCESS)) {

--- a/library/src/cuda_hook.c
+++ b/library/src/cuda_hook.c
@@ -455,6 +455,8 @@ CUresult cuMemFree_v2(CUdeviceptr dptr);
 CUresult cuMemFree(CUdeviceptr dptr);
 CUresult cuMemFreeAsync(CUdeviceptr dptr, CUstream hStream);
 CUresult cuMemFreeAsync_ptsz(CUdeviceptr dptr, CUstream hStream);
+CUresult cuStreamEndCapture(CUstream hStream, CUgraph *phGraph);
+CUresult cuStreamEndCapture_ptsz(CUstream hStream, CUgraph *phGraph);
 
 entry_t cuda_hooks_entry[] = {
     {.name = "cuDriverGetVersion", .fn_ptr = cuDriverGetVersion},
@@ -505,6 +507,8 @@ entry_t cuda_hooks_entry[] = {
     {.name = "cuMemFree", .fn_ptr = cuMemFree},
     {.name = "cuMemFreeAsync", .fn_ptr = cuMemFreeAsync},
     {.name = "cuMemFreeAsync_ptsz", .fn_ptr = cuMemFreeAsync_ptsz},
+    {.name = "cuStreamEndCapture", .fn_ptr = cuStreamEndCapture},
+    {.name = "cuStreamEndCapture_ptsz", .fn_ptr = cuStreamEndCapture_ptsz},
 };
 
 const int cuda_hook_nums =
@@ -1443,6 +1447,51 @@ static int stream_is_capturing(CUstream stream, int ptsz) {
     return 1;
   }
   return (cap != CU_STREAM_CAPTURE_STATUS_NONE) ? 1 : 0;
+}
+
+/* Graph currently being captured into by hStream, or NULL if that cannot be
+ * established. `ptsz` selects the entry-point family, for the same reason as in
+ * stream_is_capturing().
+ *
+ * Only _v2 and _v3 report the graph; the original cuStreamGetCaptureInfo yields
+ * a status and an id only, so a driver that exports nothing newer leaves us
+ * unable to identify the capture. NULL is returned in that case, and the caller
+ * MUST then decline to charge the allocation: a charge we cannot attribute to a
+ * graph is a charge cuStreamEndCapture can never retire, which would accumulate
+ * into a permanent overstatement of usage and eventually fail every allocation.
+ * Losing the charge only costs accumulation within that one capture. */
+static CUgraph stream_capture_graph(CUstream stream, int ptsz) {
+  CUstreamCaptureStatus cap = CU_STREAM_CAPTURE_STATUS_NONE;
+  cuuint64_t id = 0;
+  CUgraph graph = NULL;
+  const CUgraphNode *deps = NULL;
+  size_t num_deps = 0;
+  CUresult ret;
+
+  cuda_entry_enum_t v3 = ptsz ? CUDA_ENTRY_ENUM(cuStreamGetCaptureInfo_v3_ptsz)
+                              : CUDA_ENTRY_ENUM(cuStreamGetCaptureInfo_v3);
+  if (cuda_library_entry[v3].fn_ptr) {
+    const CUgraphEdgeData *edges = NULL;
+    ret = ((CUresult (*)(CUstream, CUstreamCaptureStatus *, cuuint64_t *, CUgraph *,
+                         const CUgraphNode **, const CUgraphEdgeData **, size_t *))
+           cuda_library_entry[v3].fn_ptr)(stream, &cap, &id, &graph, &deps, &edges, &num_deps);
+    if (ret == CUDA_SUCCESS && cap != CU_STREAM_CAPTURE_STATUS_NONE) {
+      return graph;
+    }
+    return NULL;
+  }
+
+  cuda_entry_enum_t v2 = ptsz ? CUDA_ENTRY_ENUM(cuStreamGetCaptureInfo_v2_ptsz)
+                              : CUDA_ENTRY_ENUM(cuStreamGetCaptureInfo_v2);
+  if (cuda_library_entry[v2].fn_ptr) {
+    ret = ((CUresult (*)(CUstream, CUstreamCaptureStatus *, cuuint64_t *, CUgraph *,
+                         const CUgraphNode **, size_t *))
+           cuda_library_entry[v2].fn_ptr)(stream, &cap, &id, &graph, &deps, &num_deps);
+    if (ret == CUDA_SUCCESS && cap != CU_STREAM_CAPTURE_STATUS_NONE) {
+      return graph;
+    }
+  }
+  return NULL;
 }
 
 /* Returns 1 if this launch enters the GAP path -- the caller MUST then call
@@ -2731,8 +2780,13 @@ ALLOCATED_TO_GPU:
       /* Release internal accounting only once NVML is guaranteed to see it. */
       free_gpu_virt_memory(*dptr, host_index);
     } else {
-      // Recorded as virtual memory count during capture
-      malloc_gpu_virt_memory(*dptr, bytesize, MEMORY_TYPE_CAPTURE, host_index);
+      /* Charge the capture so that several allocations inside one capture
+       * accumulate against the limit. Chargeable only while the owning graph is
+       * known, because that is what lets cuStreamEndCapture retire it. */
+      CUgraph graph = stream_capture_graph(hStream, __CUDA_API_IS_PTSZ);
+      if (graph != NULL) {
+        malloc_gpu_virt_memory_captured(*dptr, bytesize, graph, host_index);
+      }
     }
     goto DONE;
   } else {
@@ -2800,8 +2854,13 @@ ALLOCATED_TO_GPU:
       /* Release internal accounting only once NVML is guaranteed to see it. */
       free_gpu_virt_memory(*dptr, host_index);
     } else {
-      // Recorded as virtual memory count during capture
-      malloc_gpu_virt_memory(*dptr, bytesize, MEMORY_TYPE_CAPTURE, host_index);
+      /* Charge the capture so that several allocations inside one capture
+       * accumulate against the limit. Chargeable only while the owning graph is
+       * known, because that is what lets cuStreamEndCapture retire it. */
+      CUgraph graph = stream_capture_graph(hStream, 1);
+      if (graph != NULL) {
+        malloc_gpu_virt_memory_captured(*dptr, bytesize, graph, host_index);
+      }
     }
     goto DONE;
   } else {
@@ -3806,8 +3865,13 @@ CALL:
       /* Release internal accounting only once NVML is guaranteed to see it. */
       free_gpu_virt_memory(*dptr, host_index);
     } else {
-      // Recorded as virtual memory count during capture
-      malloc_gpu_virt_memory(*dptr, bytesize, MEMORY_TYPE_CAPTURE, host_index);
+      /* Charge the capture so that several allocations inside one capture
+       * accumulate against the limit. Chargeable only while the owning graph is
+       * known, because that is what lets cuStreamEndCapture retire it. */
+      CUgraph graph = stream_capture_graph(hStream, __CUDA_API_IS_PTSZ);
+      if (graph != NULL) {
+        malloc_gpu_virt_memory_captured(*dptr, bytesize, graph, host_index);
+      }
     }
   } else if (ret == CUDA_ERROR_OUT_OF_MEMORY) {
     metrics_record_oom(host_index, METRICS_OOM_DRIVER_RETURN);
@@ -3855,8 +3919,13 @@ CALL:
       /* Release internal accounting only once NVML is guaranteed to see it. */
       free_gpu_virt_memory(*dptr, host_index);
     } else {
-      // Recorded as virtual memory count during capture
-      malloc_gpu_virt_memory(*dptr, bytesize, MEMORY_TYPE_CAPTURE, host_index);
+      /* Charge the capture so that several allocations inside one capture
+       * accumulate against the limit. Chargeable only while the owning graph is
+       * known, because that is what lets cuStreamEndCapture retire it. */
+      CUgraph graph = stream_capture_graph(hStream, 1);
+      if (graph != NULL) {
+        malloc_gpu_virt_memory_captured(*dptr, bytesize, graph, host_index);
+      }
     }
   } else if (ret == CUDA_ERROR_OUT_OF_MEMORY) {
     metrics_record_oom(host_index, METRICS_OOM_DRIVER_RETURN);
@@ -3981,4 +4050,37 @@ CUresult cuMemFreeAsync_ptsz(CUdeviceptr dptr, CUstream hStream) {
   }
 DONE:
   return ret;
+}
+
+/* End of capture is where a capture charge is retired: past this point the
+ * allocations belong to the graph, and once it is launched NVML reports them.
+ *
+ * Two things are deliberately unconditional here.
+ *
+ * The graph is resolved BEFORE ending the capture, because a capture that has
+ * been invalidated makes cuStreamEndCapture fail and leave *phGraph NULL, and
+ * the charge still has to come off in that case.
+ *
+ * The discharge itself ignores the driver's verdict. Whether the graph was
+ * built or thrown away, no memory is held on its behalf yet, so there is
+ * nothing a failure could justify keeping. Any path that skips the discharge
+ * strands the charge in the shared counter for the life of the process, which
+ * is a false OOM waiting to happen -- strictly worse than briefly under-counting
+ * memory that does not exist yet. free_gpu_virt_memory_by_graph() therefore
+ * needs no device argument and cannot fail. */
+static CUresult end_capture_and_discharge(CUstream hStream, CUgraph *phGraph, int ptsz) {
+  CUgraph capturing = stream_capture_graph(hStream, ptsz);
+  CUresult ret = ptsz
+      ? CUDA_ENTRY_CHECK(cuda_library_entry, cuStreamEndCapture_ptsz, hStream, phGraph)
+      : CUDA_ENTRY_CHECK(cuda_library_entry, cuStreamEndCapture, hStream, phGraph);
+  free_gpu_virt_memory_by_graph(capturing);
+  return ret;
+}
+
+CUresult cuStreamEndCapture(CUstream hStream, CUgraph *phGraph) {
+  return end_capture_and_discharge(hStream, phGraph, __CUDA_API_IS_PTSZ);
+}
+
+CUresult cuStreamEndCapture_ptsz(CUstream hStream, CUgraph *phGraph) {
+  return end_capture_and_discharge(hStream, phGraph, 1);
 }

--- a/library/src/cuda_hook.c
+++ b/library/src/cuda_hook.c
@@ -460,6 +460,7 @@ CUresult cuStreamEndCapture_ptsz(CUstream hStream, CUgraph *phGraph);
 CUresult cuGraphDestroy(CUgraph hGraph);
 CUresult cuMemHostRegister(void *p, size_t bytesize, unsigned int Flags);
 CUresult cuMemHostRegister_v2(void *p, size_t bytesize, unsigned int Flags);
+CUresult cuMemHostAlloc(void **pp, size_t bytesize, unsigned int Flags);
 
 entry_t cuda_hooks_entry[] = {
     {.name = "cuDriverGetVersion", .fn_ptr = cuDriverGetVersion},
@@ -515,6 +516,7 @@ entry_t cuda_hooks_entry[] = {
     {.name = "cuGraphDestroy", .fn_ptr = cuGraphDestroy},
     {.name = "cuMemHostRegister", .fn_ptr = cuMemHostRegister},
     {.name = "cuMemHostRegister_v2", .fn_ptr = cuMemHostRegister_v2},
+    {.name = "cuMemHostAlloc", .fn_ptr = cuMemHostAlloc},
 };
 
 const int cuda_hook_nums =
@@ -4151,3 +4153,27 @@ CUresult cuMemHostRegister_v2(void *p, size_t bytesize, unsigned int Flags) {
 CUresult cuMemHostRegister(void *p, size_t bytesize, unsigned int Flags) {
   return _cuMemHostRegister(p, bytesize, Flags);
 }
+
+CUresult cuMemHostAlloc(void **pp, size_t bytesize, unsigned int Flags) {
+  int lock_fd = -1;
+  CUresult ret = CUDA_ENTRY_CHECK(cuda_library_entry, cuMemHostAlloc, pp, bytesize, Flags);
+  if (likely(ret == CUDA_SUCCESS)) {
+    CUdevice device;
+    if (unlikely(CUDA_INTERNAL_CHECK(cuda_library_entry, cuCtxGetDevice, &device) != CUDA_SUCCESS)) {
+      goto DONE;
+    }
+    // Post check for exceeding memory limit.
+    int host_index = -1;
+    if (prepare_memory_allocation(device, 0, 0, &host_index, &lock_fd) == MEMORY_PATH_OOM) {
+      metrics_record_oom(host_index, METRICS_OOM_TOTAL_LIMIT);
+      if (CUDA_INTERNAL_CHECK(cuda_library_entry, cuMemFreeHost, *pp) == CUDA_SUCCESS) {
+        *pp = NULL;
+      }
+      ret = CUDA_ERROR_OUT_OF_MEMORY;
+    }
+  }
+DONE:
+  unlock_gpu_device(lock_fd);
+  return ret;
+}
+

--- a/library/src/cuda_hook.c
+++ b/library/src/cuda_hook.c
@@ -287,9 +287,15 @@ static memory_path_t prepare_memory_allocation(CUdevice device,
     return MEMORY_PATH_GPU;
   }
 
-  if ((used + vmem_used + request_size) >
-      g_vgpu_config->devices[*host_index].total_memory) {
-    return MEMORY_PATH_OOM;
+  if ((used + vmem_used + request_size) > g_vgpu_config->devices[*host_index].total_memory) {
+    // It is necessary to check and clean up virtual memory usage
+    if (vmem_used > 0 && (used + request_size) <= g_vgpu_config->devices[*host_index].total_memory) {
+      check_cleanup_vmem_nodes_by_device(*host_index);
+      get_used_gpu_virt_memory((void *)&vmem_used, *host_index);
+    }
+    if ((used + vmem_used + request_size) > g_vgpu_config->devices[*host_index].total_memory) {
+      return MEMORY_PATH_OOM;
+    }
   }
 
   if (allow_uva && g_vgpu_config->devices[*host_index].memory_oversold &&
@@ -2721,11 +2727,9 @@ ALLOCATED_TO_GPU:
       unlock_gpu_device(lock_fd);
       lock_fd = -1;
       /* Switching from capture to synchronous operation, off the device lock. */
-      CUresult sync_ret = CUDA_INTERNAL_CHECK(cuda_library_entry, __CUDA_API_PTSZ(cuStreamSynchronize), hStream);
+      CUDA_INTERNAL_CHECK(cuda_library_entry, __CUDA_API_PTSZ(cuStreamSynchronize), hStream);
       /* Release internal accounting only once NVML is guaranteed to see it. */
-      if (likely(sync_ret == CUDA_SUCCESS)) {
-        free_gpu_virt_memory(*dptr, host_index);
-      }
+      free_gpu_virt_memory(*dptr, host_index);
     } else {
       // Recorded as virtual memory count during capture
       malloc_gpu_virt_memory(*dptr, bytesize, MEMORY_TYPE_CAPTURE, host_index);
@@ -2792,11 +2796,9 @@ ALLOCATED_TO_GPU:
       unlock_gpu_device(lock_fd);
       lock_fd = -1;
       /* Switching from capture to synchronous operation, off the device lock. */
-      CUresult sync_ret = CUDA_INTERNAL_CHECK(cuda_library_entry, cuStreamSynchronize_ptsz, hStream);
+      CUDA_INTERNAL_CHECK(cuda_library_entry, cuStreamSynchronize_ptsz, hStream);
       /* Release internal accounting only once NVML is guaranteed to see it. */
-      if (likely(sync_ret == CUDA_SUCCESS)) {
-        free_gpu_virt_memory(*dptr, host_index);
-      }
+      free_gpu_virt_memory(*dptr, host_index);
     } else {
       // Recorded as virtual memory count during capture
       malloc_gpu_virt_memory(*dptr, bytesize, MEMORY_TYPE_CAPTURE, host_index);
@@ -3800,11 +3802,9 @@ CALL:
       unlock_gpu_device(lock_fd);
       lock_fd = -1;
       /* Switching from capture to synchronous operation, off the device lock. */
-      CUresult sync_ret = CUDA_INTERNAL_CHECK(cuda_library_entry, __CUDA_API_PTSZ(cuStreamSynchronize), hStream);
+      CUDA_INTERNAL_CHECK(cuda_library_entry, __CUDA_API_PTSZ(cuStreamSynchronize), hStream);
       /* Release internal accounting only once NVML is guaranteed to see it. */
-      if (likely(sync_ret == CUDA_SUCCESS)) {
-        free_gpu_virt_memory(*dptr, host_index);
-      }
+      free_gpu_virt_memory(*dptr, host_index);
     } else {
       // Recorded as virtual memory count during capture
       malloc_gpu_virt_memory(*dptr, bytesize, MEMORY_TYPE_CAPTURE, host_index);
@@ -3851,11 +3851,9 @@ CALL:
       unlock_gpu_device(lock_fd);
       lock_fd = -1;
       /* Switching from capture to synchronous operation, off the device lock. */
-      CUresult sync_ret = CUDA_INTERNAL_CHECK(cuda_library_entry, cuStreamSynchronize_ptsz, hStream);
+      CUDA_INTERNAL_CHECK(cuda_library_entry, cuStreamSynchronize_ptsz, hStream);
       /* Release internal accounting only once NVML is guaranteed to see it. */
-      if (likely(sync_ret == CUDA_SUCCESS)) {
-        free_gpu_virt_memory(*dptr, host_index);
-      }
+      free_gpu_virt_memory(*dptr, host_index);
     } else {
       // Recorded as virtual memory count during capture
       malloc_gpu_virt_memory(*dptr, bytesize, MEMORY_TYPE_CAPTURE, host_index);

--- a/library/src/cuda_hook.c
+++ b/library/src/cuda_hook.c
@@ -2713,7 +2713,7 @@ ALLOCATED_TO_GPU:
     } else {
       goto DONE;
     }
-  } else if (ret == CUDA_SUCCESS) {
+  } else if (ret == CUDA_SUCCESS && lock_fd >= 0) {
     if (!stream_is_capturing(hStream, __CUDA_API_IS_PTSZ)) {
       // Internal bookkeeping before synchronization is completed
       malloc_gpu_virt_memory(*dptr, bytesize, 3, host_index);
@@ -2779,7 +2779,7 @@ ALLOCATED_TO_GPU:
     } else {
       goto DONE;
     }
-  } else if (ret == CUDA_SUCCESS) {
+  } else if (ret == CUDA_SUCCESS && lock_fd >= 0) {
     if (!stream_is_capturing(hStream, 1)) {
       // Internal bookkeeping before synchronization is completed
       malloc_gpu_virt_memory(*dptr, bytesize, 3, host_index);
@@ -3782,7 +3782,7 @@ CUresult cuMemAllocFromPoolAsync(CUdeviceptr *dptr, size_t bytesize,
   }
 CALL:
   ret = CUDA_ENTRY_CHECK(cuda_library_entry, __CUDA_API_PTSZ(cuMemAllocFromPoolAsync), dptr, bytesize, pool, hStream);
-  if (ret == CUDA_SUCCESS) {
+  if (ret == CUDA_SUCCESS && lock_fd >= 0) {
     if (!stream_is_capturing(hStream, __CUDA_API_IS_PTSZ)) {
       // Internal bookkeeping before synchronization is completed
       malloc_gpu_virt_memory(*dptr, bytesize, 3, host_index);
@@ -3827,7 +3827,8 @@ CUresult cuMemAllocFromPoolAsync_ptsz(CUdeviceptr *dptr, size_t bytesize,
   }
 CALL:
   ret = CUDA_ENTRY_CHECK(cuda_library_entry, cuMemAllocFromPoolAsync_ptsz, dptr, bytesize, pool, hStream);
-  if (ret == CUDA_SUCCESS) {
+  // Confirm successful locking and waive the cost of unopened containers
+  if (ret == CUDA_SUCCESS && lock_fd >= 0) {
     if (!stream_is_capturing(hStream, 1)) {
       // Internal bookkeeping before synchronization is completed
       malloc_gpu_virt_memory(*dptr, bytesize, 3, host_index);

--- a/library/src/cuda_hook.c
+++ b/library/src/cuda_hook.c
@@ -458,6 +458,8 @@ CUresult cuMemFreeAsync_ptsz(CUdeviceptr dptr, CUstream hStream);
 CUresult cuStreamEndCapture(CUstream hStream, CUgraph *phGraph);
 CUresult cuStreamEndCapture_ptsz(CUstream hStream, CUgraph *phGraph);
 CUresult cuGraphDestroy(CUgraph hGraph);
+CUresult cuMemHostRegister(void *p, size_t bytesize, unsigned int Flags);
+CUresult cuMemHostRegister_v2(void *p, size_t bytesize, unsigned int Flags);
 
 entry_t cuda_hooks_entry[] = {
     {.name = "cuDriverGetVersion", .fn_ptr = cuDriverGetVersion},
@@ -511,6 +513,8 @@ entry_t cuda_hooks_entry[] = {
     {.name = "cuStreamEndCapture", .fn_ptr = cuStreamEndCapture},
     {.name = "cuStreamEndCapture_ptsz", .fn_ptr = cuStreamEndCapture_ptsz},
     {.name = "cuGraphDestroy", .fn_ptr = cuGraphDestroy},
+    {.name = "cuMemHostRegister", .fn_ptr = cuMemHostRegister},
+    {.name = "cuMemHostRegister_v2", .fn_ptr = cuMemHostRegister_v2},
 };
 
 const int cuda_hook_nums =
@@ -4112,4 +4116,38 @@ CUresult cuGraphDestroy(CUgraph hGraph) {
   CUresult ret = CUDA_ENTRY_CHECK(cuda_library_entry, cuGraphDestroy, hGraph);
   free_gpu_virt_memory_by_graph(hGraph);
   return ret;
+}
+
+CUresult _cuMemHostRegister(void *p, size_t bytesize, unsigned int Flags) {
+  int lock_fd = -1;
+  CUresult ret = CUDA_ERROR_NOT_FOUND;
+  if (likely(CUDA_FIND_ENTRY(cuda_library_entry, cuMemHostRegister_v2))) {
+    ret = CUDA_ENTRY_CHECK(cuda_library_entry, cuMemHostRegister_v2, p, bytesize, Flags);
+  } else if (likely(CUDA_FIND_ENTRY(cuda_library_entry, cuMemHostRegister))) {
+    ret = CUDA_ENTRY_CHECK(cuda_library_entry, cuMemHostRegister, p, bytesize, Flags);
+  }
+  if (likely(ret == CUDA_SUCCESS)) {
+    CUdevice device;
+    if (unlikely(CUDA_INTERNAL_CHECK(cuda_library_entry, cuCtxGetDevice, &device) != CUDA_SUCCESS)) {
+      goto DONE;
+    }
+    // Post check for exceeding memory limit.
+    int host_index = -1;
+    if (prepare_memory_allocation(device, 0, 0, &host_index, &lock_fd) == MEMORY_PATH_OOM) {
+      metrics_record_oom(host_index, METRICS_OOM_TOTAL_LIMIT);
+      CUDA_INTERNAL_CHECK(cuda_library_entry, cuMemHostUnregister, p);
+      ret = CUDA_ERROR_OUT_OF_MEMORY;
+    }
+  }
+DONE:
+  unlock_gpu_device(lock_fd);
+  return ret;
+}
+
+CUresult cuMemHostRegister_v2(void *p, size_t bytesize, unsigned int Flags) {
+  return _cuMemHostRegister(p, bytesize, Flags);
+}
+
+CUresult cuMemHostRegister(void *p, size_t bytesize, unsigned int Flags) {
+  return _cuMemHostRegister(p, bytesize, Flags);
 }

--- a/library/src/cuda_hook.c
+++ b/library/src/cuda_hook.c
@@ -2497,16 +2497,16 @@ CUresult cuMemAllocManaged(CUdeviceptr *dptr, size_t bytesize, unsigned int flag
   CUresult ret;
   CUdevice device;
   int lock_fd = -1;
+  int host_index = -1;
   memory_path_t path;
   /* NULL-arg fast path; same rationale as _cuMemAlloc above. */
   if (unlikely(dptr == NULL)) {
-    return CUDA_ENTRY_CHECK(cuda_library_entry, cuMemAllocManaged, dptr, bytesize, flags);
+    goto CALL;
   }
   ret = CUDA_INTERNAL_CHECK(cuda_library_entry, cuCtxGetDevice, &device);
   if (unlikely(ret != CUDA_SUCCESS)) {
     goto DONE;
   }
-  int host_index = -1;
   path = prepare_memory_allocation(device, bytesize, 1, &host_index, &lock_fd);
   if (path == MEMORY_PATH_OOM) {
     metrics_record_oom(host_index, METRICS_OOM_TOTAL_LIMIT);
@@ -2516,9 +2516,12 @@ CUresult cuMemAllocManaged(CUdeviceptr *dptr, size_t bytesize, unsigned int flag
   if (path == MEMORY_PATH_UVA) {
     flags = CU_MEM_ATTACH_GLOBAL;
   }
+CALL:
   ret = CUDA_ENTRY_CHECK(cuda_library_entry, cuMemAllocManaged, dptr, bytesize, flags);
   if (likely(ret == CUDA_SUCCESS)) {
-    if (flags == CU_MEM_ATTACH_GLOBAL) malloc_gpu_virt_memory(*dptr, bytesize, host_index);
+    if (flags == CU_MEM_ATTACH_GLOBAL) {
+      malloc_gpu_virt_memory(*dptr, bytesize, 1, host_index);
+    }
   } else if (ret == CUDA_ERROR_OUT_OF_MEMORY) {
     metrics_record_oom(host_index, METRICS_OOM_DRIVER_RETURN);
   }
@@ -2531,6 +2534,8 @@ CUresult _cuMemAlloc(CUdeviceptr *dptr, size_t bytesize) {
   CUresult ret;
   CUdevice device;
   int lock_fd = -1;
+  int host_index = -1;
+  size_t request_size = bytesize;
   memory_path_t path;
   /* NULL-arg fast path: defensive early return matching HAMi PR #182
    * commit 88143ab4. Existing logic is already structurally safe
@@ -2539,19 +2544,12 @@ CUresult _cuMemAlloc(CUdeviceptr *dptr, size_t bytesize) {
    * forwarding immediately avoids the budget check + lock acquisition
    * for what is always a probe / fallback / invalid call. */
   if (unlikely(dptr == NULL)) {
-    if (likely(CUDA_FIND_ENTRY(cuda_library_entry, cuMemAlloc_v2))) {
-      return CUDA_ENTRY_CHECK(cuda_library_entry, cuMemAlloc_v2, dptr, bytesize);
-    } else if (likely(CUDA_FIND_ENTRY(cuda_library_entry, cuMemAlloc))) {
-      return CUDA_ENTRY_CHECK(cuda_library_entry, cuMemAlloc, dptr, bytesize);
-    }
-    return CUDA_ERROR_NOT_FOUND;
+    goto ALLOCATED_TO_GPU;
   }
   ret = CUDA_INTERNAL_CHECK(cuda_library_entry, cuCtxGetDevice, &device);
   if (unlikely(ret != CUDA_SUCCESS)) {
     goto DONE;
   }
-  size_t request_size = bytesize;
-  int host_index = -1;
   path = prepare_memory_allocation(device, request_size, 1, &host_index, &lock_fd);
   if (path == MEMORY_PATH_OOM) {
     metrics_record_oom(host_index, METRICS_OOM_TOTAL_LIMIT);
@@ -2561,7 +2559,7 @@ CUresult _cuMemAlloc(CUdeviceptr *dptr, size_t bytesize) {
   if (path == MEMORY_PATH_UVA) {
     goto ALLOCATED_TO_UVA;
   }
-
+ALLOCATED_TO_GPU:
   if (likely(CUDA_FIND_ENTRY(cuda_library_entry, cuMemAlloc_v2))) {
     ret = CUDA_ENTRY_CHECK(cuda_library_entry, cuMemAlloc_v2, dptr, bytesize);
   } else if (likely(CUDA_FIND_ENTRY(cuda_library_entry, cuMemAlloc))) {
@@ -2586,7 +2584,7 @@ ALLOCATED_TO_UVA:
   LOGGER(VERBOSE, "cuMemAllocManaged to allocate unified memory (oversold), size: %zu, ret: %d, str: %s",
                    request_size, ret, CUDA_ERROR(cuda_library_entry, ret));
   if (likely(ret == CUDA_SUCCESS)) {
-    malloc_gpu_virt_memory(*dptr, bytesize, host_index);
+    malloc_gpu_virt_memory(*dptr, bytesize, 1, host_index);
   } else if (ret == CUDA_ERROR_OUT_OF_MEMORY) {
     metrics_record_oom(host_index, METRICS_OOM_DRIVER_RETURN);
   }
@@ -2608,29 +2606,21 @@ CUresult _cuMemAllocPitch(CUdeviceptr *dptr, size_t *pPitch, size_t WidthInBytes
   CUresult ret;
   CUdevice device;
   int lock_fd = -1;
+  int host_index = -1;
+  // size_t request_size = ROUND_UP(WidthInBytes * Height, ElementSizeBytes);
+  size_t guess_pitch = (((WidthInBytes - 1) / ElementSizeBytes) + 1) * ElementSizeBytes;
+  size_t request_size = guess_pitch * Height;
   memory_path_t path;
   /* NULL-arg fast path. The UVA fallback below dereferences *pPitch
    * unconditionally; *dptr deref is guarded by ret==SUCCESS but cheap
    * to short-circuit anyway. Forward to driver for INVALID_VALUE. */
   if (unlikely(dptr == NULL || pPitch == NULL)) {
-    if (likely(CUDA_FIND_ENTRY(cuda_library_entry, cuMemAllocPitch_v2))) {
-      return CUDA_ENTRY_CHECK(cuda_library_entry, cuMemAllocPitch_v2,
-                               dptr, pPitch, WidthInBytes, Height, ElementSizeBytes);
-    } else if (likely(CUDA_FIND_ENTRY(cuda_library_entry, cuMemAllocPitch))) {
-      return CUDA_ENTRY_CHECK(cuda_library_entry, cuMemAllocPitch,
-                               dptr, pPitch, WidthInBytes, Height, ElementSizeBytes);
-    }
-    return CUDA_ERROR_NOT_FOUND;
+    goto ALLOCATED_TO_GPU;
   }
   ret = CUDA_INTERNAL_CHECK(cuda_library_entry, cuCtxGetDevice, &device);
   if (unlikely(ret != CUDA_SUCCESS)) {
     goto DONE;
   }
-  // size_t request_size = ROUND_UP(WidthInBytes * Height, ElementSizeBytes);
-  size_t guess_pitch = (((WidthInBytes - 1) / ElementSizeBytes) + 1) * ElementSizeBytes;
-  size_t request_size = guess_pitch * Height;
-
-  int host_index = -1;
   path = prepare_memory_allocation(device, request_size, 1, &host_index, &lock_fd);
   if (path == MEMORY_PATH_OOM) {
     metrics_record_oom(host_index, METRICS_OOM_TOTAL_LIMIT);
@@ -2640,7 +2630,7 @@ CUresult _cuMemAllocPitch(CUdeviceptr *dptr, size_t *pPitch, size_t WidthInBytes
   if (path == MEMORY_PATH_UVA) {
     goto ALLOCATED_TO_UVA;
   }
-
+ALLOCATED_TO_GPU:
   if (likely(CUDA_FIND_ENTRY(cuda_library_entry, cuMemAllocPitch_v2))) {
     ret = CUDA_ENTRY_CHECK(cuda_library_entry, cuMemAllocPitch_v2, dptr, pPitch, WidthInBytes, Height, ElementSizeBytes);
   } else if (likely(CUDA_FIND_ENTRY(cuda_library_entry, cuMemAllocPitch))) {
@@ -2666,7 +2656,7 @@ ALLOCATED_TO_UVA:
                   request_size, ret, CUDA_ERROR(cuda_library_entry, ret));
   if (likely(ret == CUDA_SUCCESS)) {
     *pPitch = guess_pitch;
-    malloc_gpu_virt_memory(*dptr, request_size, host_index);
+    malloc_gpu_virt_memory(*dptr, request_size, 1, host_index);
   } else if (ret == CUDA_ERROR_OUT_OF_MEMORY) {
     metrics_record_oom(host_index, METRICS_OOM_DRIVER_RETURN);
   }
@@ -2690,17 +2680,17 @@ CUresult cuMemAllocAsync(CUdeviceptr *dptr, size_t bytesize, CUstream hStream) {
   CUresult ret;
   CUdevice device;
   int lock_fd = -1;
+  int host_index = -1;
+  size_t request_size = bytesize;
   memory_path_t path;
   /* NULL-arg fast path; same rationale as _cuMemAlloc above. */
   if (unlikely(dptr == NULL)) {
-    return CUDA_ENTRY_CHECK(cuda_library_entry, __CUDA_API_PTSZ(cuMemAllocAsync), dptr, bytesize, hStream);
+    goto ALLOCATED_TO_GPU;
   }
   ret = CUDA_INTERNAL_CHECK(cuda_library_entry, cuCtxGetDevice, &device);
   if (unlikely(ret != CUDA_SUCCESS)) {
     goto DONE;
   }
-  size_t request_size = bytesize;
-  int host_index = -1;
   path = prepare_memory_allocation(device, request_size, 1, &host_index, &lock_fd);
   if (path == MEMORY_PATH_OOM) {
     metrics_record_oom(host_index, METRICS_OOM_TOTAL_LIMIT);
@@ -2711,6 +2701,7 @@ CUresult cuMemAllocAsync(CUdeviceptr *dptr, size_t bytesize, CUstream hStream) {
   if (path == MEMORY_PATH_UVA && !stream_is_capturing(hStream, __CUDA_API_IS_PTSZ)) {
     goto ALLOCATED_TO_UVA;
   }
+ALLOCATED_TO_GPU:
   ret = CUDA_ENTRY_CHECK(cuda_library_entry, __CUDA_API_PTSZ(cuMemAllocAsync), dptr, bytesize, hStream);
   if (unlikely(ret == CUDA_ERROR_OUT_OF_MEMORY)) {
     metrics_record_oom(host_index, METRICS_OOM_DRIVER_RETURN);
@@ -2722,6 +2713,15 @@ CUresult cuMemAllocAsync(CUdeviceptr *dptr, size_t bytesize, CUstream hStream) {
     } else {
       goto DONE;
     }
+  } else if (ret == CUDA_SUCCESS) {
+    if (!stream_is_capturing(hStream, __CUDA_API_IS_PTSZ)) {
+      // Switching from capture to synchronous operation
+      CUDA_INTERNAL_CHECK(cuda_library_entry, __CUDA_API_PTSZ(cuStreamSynchronize), hStream);
+    } else {
+      // Recorded as virtual memory count during capture
+      malloc_gpu_virt_memory(*dptr, bytesize, 3, host_index);
+    }
+    goto DONE;
   } else {
     goto DONE;
   }
@@ -2730,7 +2730,7 @@ ALLOCATED_TO_UVA:
   LOGGER(VERBOSE, "cuMemAllocManaged to allocate unified memory (oversold), size: %zu, ret: %d, str: %s",
                   request_size, ret, CUDA_ERROR(cuda_library_entry, ret));
   if (likely(ret == CUDA_SUCCESS)) {
-    malloc_gpu_virt_memory(*dptr, bytesize, host_index);
+    malloc_gpu_virt_memory(*dptr, bytesize, 2, host_index);
   } else if (ret == CUDA_ERROR_OUT_OF_MEMORY) {
     metrics_record_oom(host_index, METRICS_OOM_DRIVER_RETURN);
   }
@@ -2743,17 +2743,17 @@ CUresult cuMemAllocAsync_ptsz(CUdeviceptr *dptr, size_t bytesize, CUstream hStre
   CUresult ret;
   CUdevice device;
   int lock_fd = -1;
+  int host_index = -1;
+  size_t request_size = bytesize;
   memory_path_t path;
   /* NULL-arg fast path; same rationale as _cuMemAlloc above. */
   if (unlikely(dptr == NULL)) {
-    return CUDA_ENTRY_CHECK(cuda_library_entry, cuMemAllocAsync_ptsz, dptr, bytesize, hStream);
+    goto ALLOCATED_TO_GPU;
   }
   ret = CUDA_INTERNAL_CHECK(cuda_library_entry, cuCtxGetDevice, &device);
   if (unlikely(ret != CUDA_SUCCESS)) {
     goto DONE;
   }
-  size_t request_size = bytesize;
-  int host_index = -1;
   path = prepare_memory_allocation(device, request_size, 1, &host_index, &lock_fd);
   if (path == MEMORY_PATH_OOM) {
     metrics_record_oom(host_index, METRICS_OOM_TOTAL_LIMIT);
@@ -2763,18 +2763,27 @@ CUresult cuMemAllocAsync_ptsz(CUdeviceptr *dptr, size_t bytesize, CUstream hStre
   if (path == MEMORY_PATH_UVA && !stream_is_capturing(hStream, 1)) {
     goto ALLOCATED_TO_UVA;
   }
+ALLOCATED_TO_GPU:
   ret = CUDA_ENTRY_CHECK(cuda_library_entry, cuMemAllocAsync_ptsz, dptr, bytesize, hStream);
   if (unlikely(ret == CUDA_ERROR_OUT_OF_MEMORY)) {
     metrics_record_oom(host_index, METRICS_OOM_DRIVER_RETURN);
     // TODO Do not disrupt graph capture due to UVA path destruction
-    if (host_index >= 0 && g_vgpu_config->devices[host_index].memory_oversold &&
-        !stream_is_capturing(hStream, 1)) {
+    if (host_index >= 0 && g_vgpu_config->devices[host_index].memory_oversold && !stream_is_capturing(hStream, 1)) {
       metrics_record_uva_fallback(host_index);
       LOGGER(VERBOSE, "cuMemAllocAsync_ptsz OOM, try using unified memory allocation (oversold), size: %zu, ret: %d, str: %s",
                     request_size, ret, CUDA_ERROR(cuda_library_entry, ret));
     } else {
       goto DONE;
     }
+  } else if (ret == CUDA_SUCCESS) {
+    if (!stream_is_capturing(hStream, 1)) {
+      // Switching from capture to synchronous operation
+      CUDA_INTERNAL_CHECK(cuda_library_entry, cuStreamSynchronize_ptsz, hStream);
+    } else {
+      // Recorded as virtual memory count during capture
+      malloc_gpu_virt_memory(*dptr, bytesize, 3, host_index);
+    }
+    goto DONE;
   } else {
     goto DONE;
   }
@@ -2783,7 +2792,7 @@ ALLOCATED_TO_UVA:
   LOGGER(VERBOSE, "cuMemAllocManaged to allocate unified memory (oversold), size: %zu, ret: %d, str: %s",
                   request_size, ret, CUDA_ERROR(cuda_library_entry, ret));
   if (likely(ret == CUDA_SUCCESS)) {
-    malloc_gpu_virt_memory(*dptr, request_size, host_index);
+    malloc_gpu_virt_memory(*dptr, request_size, 2, host_index);
   } else if (ret == CUDA_ERROR_OUT_OF_MEMORY) {
     metrics_record_oom(host_index, METRICS_OOM_DRIVER_RETURN);
   }
@@ -3765,7 +3774,15 @@ CUresult cuMemAllocFromPoolAsync(CUdeviceptr *dptr, size_t bytesize,
   }
 CALL:
   ret = CUDA_ENTRY_CHECK(cuda_library_entry, __CUDA_API_PTSZ(cuMemAllocFromPoolAsync), dptr, bytesize, pool, hStream);
-  if (ret == CUDA_ERROR_OUT_OF_MEMORY) {
+  if (ret == CUDA_SUCCESS) {
+    if (!stream_is_capturing(hStream, __CUDA_API_IS_PTSZ)) {
+      // Switching from capture to synchronous operation
+      CUDA_INTERNAL_CHECK(cuda_library_entry, __CUDA_API_PTSZ(cuStreamSynchronize), hStream);
+    } else {
+      // Recorded as virtual memory count during capture
+      malloc_gpu_virt_memory(*dptr, bytesize, 3, host_index);
+    }
+  } else if (ret == CUDA_ERROR_OUT_OF_MEMORY) {
     metrics_record_oom(host_index, METRICS_OOM_DRIVER_RETURN);
   }
 DONE:
@@ -3798,7 +3815,15 @@ CUresult cuMemAllocFromPoolAsync_ptsz(CUdeviceptr *dptr, size_t bytesize,
   }
 CALL:
   ret = CUDA_ENTRY_CHECK(cuda_library_entry, cuMemAllocFromPoolAsync_ptsz, dptr, bytesize, pool, hStream);
-  if (ret == CUDA_ERROR_OUT_OF_MEMORY) {
+  if (ret == CUDA_SUCCESS) {
+    if (!stream_is_capturing(hStream, 1)) {
+      // Switching from capture to synchronous operation
+      CUDA_INTERNAL_CHECK(cuda_library_entry, cuStreamSynchronize_ptsz, hStream);
+    } else {
+      // Recorded as virtual memory count during capture
+      malloc_gpu_virt_memory(*dptr, bytesize, 3, host_index);
+    }
+  } else if (ret == CUDA_ERROR_OUT_OF_MEMORY) {
     metrics_record_oom(host_index, METRICS_OOM_DRIVER_RETURN);
   }
 DONE:
@@ -3843,7 +3868,7 @@ CUresult cuMemFree(CUdeviceptr dptr) {
 /* ptsz selects which default stream hStream==0 denotes, so both the capture
  * query and the synchronize must come from the same family as the
  * cuMemFreeAsync entry point we intercepted. */
-static CUresult free_virt_memory_on_stream(CUdeviceptr dptr, CUstream hStream, int ptsz) {
+static CUresult free_virt_memory_uva_on_stream(CUdeviceptr dptr, CUstream hStream, int ptsz) {
   CUresult ret;
   /* The pointer reached us from the oversold UVA fallback, so the only way to
    * release it is the non-stream-ordered cuMemFree, which has to drain the
@@ -3882,8 +3907,10 @@ static CUresult free_virt_memory_on_stream(CUdeviceptr dptr, CUstream hStream, i
 CUresult cuMemFreeAsync(CUdeviceptr dptr, CUstream hStream) {
   CUresult ret;
   CUdevice device;
-  if (unlikely(is_gpu_virt_memory(dptr))) {
-    return free_virt_memory_on_stream(dptr, hStream, __CUDA_API_IS_PTSZ);
+  int type = get_gpu_virt_memory_type(dptr);
+  if (type == 2) {
+    // If the memory type is asynchronous UVA memory record, go this branch
+    return free_virt_memory_uva_on_stream(dptr, hStream, 1);
   }
   ret = CUDA_INTERNAL_CHECK(cuda_library_entry, cuCtxGetDevice, &device);
   if (unlikely(ret != CUDA_SUCCESS)) {
@@ -3891,7 +3918,9 @@ CUresult cuMemFreeAsync(CUdeviceptr dptr, CUstream hStream) {
   }
   ret = CUDA_ENTRY_CHECK(cuda_library_entry, __CUDA_API_PTSZ(cuMemFreeAsync), dptr, hStream);
   if (likely(ret == CUDA_SUCCESS)) {
-    free_gpu_virt_memory(dptr, get_host_device_index_by_cuda_device(device));
+    if (type > 0) {
+      free_gpu_virt_memory(dptr, get_host_device_index_by_cuda_device(device));
+    }
   }
 DONE:
   return ret;
@@ -3900,8 +3929,10 @@ DONE:
 CUresult cuMemFreeAsync_ptsz(CUdeviceptr dptr, CUstream hStream) {
   CUresult ret;
   CUdevice device;
-  if (unlikely(is_gpu_virt_memory(dptr))) {
-    return free_virt_memory_on_stream(dptr, hStream, 1);
+  int type = get_gpu_virt_memory_type(dptr);
+  if (type == 2) {
+    // If the memory type is asynchronous UVA memory record, go this branch
+    return free_virt_memory_uva_on_stream(dptr, hStream, 1);
   }
   ret = CUDA_INTERNAL_CHECK(cuda_library_entry, cuCtxGetDevice, &device);
   if (unlikely(ret != CUDA_SUCCESS)) {
@@ -3909,7 +3940,9 @@ CUresult cuMemFreeAsync_ptsz(CUdeviceptr dptr, CUstream hStream) {
   }
   ret = CUDA_ENTRY_CHECK(cuda_library_entry, cuMemFreeAsync_ptsz, dptr, hStream);
   if (likely(ret == CUDA_SUCCESS)) {
-    free_gpu_virt_memory(dptr, get_host_device_index_by_cuda_device(device));
+    if (type > 0) {
+      free_gpu_virt_memory(dptr, get_host_device_index_by_cuda_device(device));
+    }
   }
 DONE:
   return ret;

--- a/library/src/cuda_hook.c
+++ b/library/src/cuda_hook.c
@@ -2520,7 +2520,7 @@ CALL:
   ret = CUDA_ENTRY_CHECK(cuda_library_entry, cuMemAllocManaged, dptr, bytesize, flags);
   if (likely(ret == CUDA_SUCCESS)) {
     if (flags == CU_MEM_ATTACH_GLOBAL) {
-      malloc_gpu_virt_memory(*dptr, bytesize, 1, host_index);
+      malloc_gpu_virt_memory(*dptr, bytesize, MEMORY_TYPE_UVA_SYNC, host_index);
     }
   } else if (ret == CUDA_ERROR_OUT_OF_MEMORY) {
     metrics_record_oom(host_index, METRICS_OOM_DRIVER_RETURN);
@@ -2584,7 +2584,7 @@ ALLOCATED_TO_UVA:
   LOGGER(VERBOSE, "cuMemAllocManaged to allocate unified memory (oversold), size: %zu, ret: %d, str: %s",
                    request_size, ret, CUDA_ERROR(cuda_library_entry, ret));
   if (likely(ret == CUDA_SUCCESS)) {
-    malloc_gpu_virt_memory(*dptr, bytesize, 1, host_index);
+    malloc_gpu_virt_memory(*dptr, bytesize, MEMORY_TYPE_UVA_SYNC, host_index);
   } else if (ret == CUDA_ERROR_OUT_OF_MEMORY) {
     metrics_record_oom(host_index, METRICS_OOM_DRIVER_RETURN);
   }
@@ -2656,7 +2656,7 @@ ALLOCATED_TO_UVA:
                   request_size, ret, CUDA_ERROR(cuda_library_entry, ret));
   if (likely(ret == CUDA_SUCCESS)) {
     *pPitch = guess_pitch;
-    malloc_gpu_virt_memory(*dptr, request_size, 1, host_index);
+    malloc_gpu_virt_memory(*dptr, request_size, MEMORY_TYPE_UVA_SYNC, host_index);
   } else if (ret == CUDA_ERROR_OUT_OF_MEMORY) {
     metrics_record_oom(host_index, METRICS_OOM_DRIVER_RETURN);
   }
@@ -2715,15 +2715,20 @@ ALLOCATED_TO_GPU:
     }
   } else if (ret == CUDA_SUCCESS && lock_fd >= 0) {
     if (!stream_is_capturing(hStream, __CUDA_API_IS_PTSZ)) {
-      // Internal bookkeeping before synchronization is completed
-      malloc_gpu_virt_memory(*dptr, bytesize, 3, host_index);
-      // Switching from capture to synchronous operation
-      CUDA_INTERNAL_CHECK(cuda_library_entry, __CUDA_API_PTSZ(cuStreamSynchronize), hStream);
-      // Release internal accounting after synchronization is completed
-      free_gpu_virt_memory(*dptr, host_index);
+      /* Bridge the allocation into the shared view before the lock is dropped,
+       * so a concurrent allocator counts it while it is still in flight. */
+      malloc_gpu_virt_memory(*dptr, bytesize, MEMORY_TYPE_ASYNC_BRIDGE, host_index);
+      unlock_gpu_device(lock_fd);
+      lock_fd = -1;
+      /* Switching from capture to synchronous operation, off the device lock. */
+      CUresult sync_ret = CUDA_INTERNAL_CHECK(cuda_library_entry, __CUDA_API_PTSZ(cuStreamSynchronize), hStream);
+      /* Release internal accounting only once NVML is guaranteed to see it. */
+      if (likely(sync_ret == CUDA_SUCCESS)) {
+        free_gpu_virt_memory(*dptr, host_index);
+      }
     } else {
       // Recorded as virtual memory count during capture
-      malloc_gpu_virt_memory(*dptr, bytesize, 3, host_index);
+      malloc_gpu_virt_memory(*dptr, bytesize, MEMORY_TYPE_CAPTURE, host_index);
     }
     goto DONE;
   } else {
@@ -2734,7 +2739,7 @@ ALLOCATED_TO_UVA:
   LOGGER(VERBOSE, "cuMemAllocManaged to allocate unified memory (oversold), size: %zu, ret: %d, str: %s",
                   request_size, ret, CUDA_ERROR(cuda_library_entry, ret));
   if (likely(ret == CUDA_SUCCESS)) {
-    malloc_gpu_virt_memory(*dptr, bytesize, 2, host_index);
+    malloc_gpu_virt_memory(*dptr, bytesize, MEMORY_TYPE_UVA_ASYNC, host_index);
   } else if (ret == CUDA_ERROR_OUT_OF_MEMORY) {
     metrics_record_oom(host_index, METRICS_OOM_DRIVER_RETURN);
   }
@@ -2781,15 +2786,20 @@ ALLOCATED_TO_GPU:
     }
   } else if (ret == CUDA_SUCCESS && lock_fd >= 0) {
     if (!stream_is_capturing(hStream, 1)) {
-      // Internal bookkeeping before synchronization is completed
-      malloc_gpu_virt_memory(*dptr, bytesize, 3, host_index);
-      // Switching from capture to synchronous operation
-      CUDA_INTERNAL_CHECK(cuda_library_entry, cuStreamSynchronize_ptsz, hStream);
-      // Release internal accounting after synchronization is completed
-      free_gpu_virt_memory(*dptr, host_index);
+      /* Bridge the allocation into the shared view before the lock is dropped,
+       * so a concurrent allocator counts it while it is still in flight. */
+      malloc_gpu_virt_memory(*dptr, bytesize, MEMORY_TYPE_ASYNC_BRIDGE, host_index);
+      unlock_gpu_device(lock_fd);
+      lock_fd = -1;
+      /* Switching from capture to synchronous operation, off the device lock. */
+      CUresult sync_ret = CUDA_INTERNAL_CHECK(cuda_library_entry, cuStreamSynchronize_ptsz, hStream);
+      /* Release internal accounting only once NVML is guaranteed to see it. */
+      if (likely(sync_ret == CUDA_SUCCESS)) {
+        free_gpu_virt_memory(*dptr, host_index);
+      }
     } else {
       // Recorded as virtual memory count during capture
-      malloc_gpu_virt_memory(*dptr, bytesize, 3, host_index);
+      malloc_gpu_virt_memory(*dptr, bytesize, MEMORY_TYPE_CAPTURE, host_index);
     }
     goto DONE;
   } else {
@@ -2800,7 +2810,7 @@ ALLOCATED_TO_UVA:
   LOGGER(VERBOSE, "cuMemAllocManaged to allocate unified memory (oversold), size: %zu, ret: %d, str: %s",
                   request_size, ret, CUDA_ERROR(cuda_library_entry, ret));
   if (likely(ret == CUDA_SUCCESS)) {
-    malloc_gpu_virt_memory(*dptr, request_size, 2, host_index);
+    malloc_gpu_virt_memory(*dptr, request_size, MEMORY_TYPE_UVA_ASYNC, host_index);
   } else if (ret == CUDA_ERROR_OUT_OF_MEMORY) {
     metrics_record_oom(host_index, METRICS_OOM_DRIVER_RETURN);
   }
@@ -3784,15 +3794,20 @@ CALL:
   ret = CUDA_ENTRY_CHECK(cuda_library_entry, __CUDA_API_PTSZ(cuMemAllocFromPoolAsync), dptr, bytesize, pool, hStream);
   if (ret == CUDA_SUCCESS && lock_fd >= 0) {
     if (!stream_is_capturing(hStream, __CUDA_API_IS_PTSZ)) {
-      // Internal bookkeeping before synchronization is completed
-      malloc_gpu_virt_memory(*dptr, bytesize, 3, host_index);
-      // Switching from capture to synchronous operation
-      CUDA_INTERNAL_CHECK(cuda_library_entry, __CUDA_API_PTSZ(cuStreamSynchronize), hStream);
-      // Release internal accounting after synchronization is completed
-      free_gpu_virt_memory(*dptr, host_index);
+      /* Bridge the allocation into the shared view before the lock is dropped,
+       * so a concurrent allocator counts it while it is still in flight. */
+      malloc_gpu_virt_memory(*dptr, bytesize, MEMORY_TYPE_ASYNC_BRIDGE, host_index);
+      unlock_gpu_device(lock_fd);
+      lock_fd = -1;
+      /* Switching from capture to synchronous operation, off the device lock. */
+      CUresult sync_ret = CUDA_INTERNAL_CHECK(cuda_library_entry, __CUDA_API_PTSZ(cuStreamSynchronize), hStream);
+      /* Release internal accounting only once NVML is guaranteed to see it. */
+      if (likely(sync_ret == CUDA_SUCCESS)) {
+        free_gpu_virt_memory(*dptr, host_index);
+      }
     } else {
       // Recorded as virtual memory count during capture
-      malloc_gpu_virt_memory(*dptr, bytesize, 3, host_index);
+      malloc_gpu_virt_memory(*dptr, bytesize, MEMORY_TYPE_CAPTURE, host_index);
     }
   } else if (ret == CUDA_ERROR_OUT_OF_MEMORY) {
     metrics_record_oom(host_index, METRICS_OOM_DRIVER_RETURN);
@@ -3830,15 +3845,20 @@ CALL:
   // Confirm successful locking and waive the cost of unopened containers
   if (ret == CUDA_SUCCESS && lock_fd >= 0) {
     if (!stream_is_capturing(hStream, 1)) {
-      // Internal bookkeeping before synchronization is completed
-      malloc_gpu_virt_memory(*dptr, bytesize, 3, host_index);
-      // Switching from capture to synchronous operation
-      CUDA_INTERNAL_CHECK(cuda_library_entry, cuStreamSynchronize_ptsz, hStream);
-      // Release internal accounting after synchronization is completed
-      free_gpu_virt_memory(*dptr, host_index);
+      /* Bridge the allocation into the shared view before the lock is dropped,
+       * so a concurrent allocator counts it while it is still in flight. */
+      malloc_gpu_virt_memory(*dptr, bytesize, MEMORY_TYPE_ASYNC_BRIDGE, host_index);
+      unlock_gpu_device(lock_fd);
+      lock_fd = -1;
+      /* Switching from capture to synchronous operation, off the device lock. */
+      CUresult sync_ret = CUDA_INTERNAL_CHECK(cuda_library_entry, cuStreamSynchronize_ptsz, hStream);
+      /* Release internal accounting only once NVML is guaranteed to see it. */
+      if (likely(sync_ret == CUDA_SUCCESS)) {
+        free_gpu_virt_memory(*dptr, host_index);
+      }
     } else {
       // Recorded as virtual memory count during capture
-      malloc_gpu_virt_memory(*dptr, bytesize, 3, host_index);
+      malloc_gpu_virt_memory(*dptr, bytesize, MEMORY_TYPE_CAPTURE, host_index);
     }
   } else if (ret == CUDA_ERROR_OUT_OF_MEMORY) {
     metrics_record_oom(host_index, METRICS_OOM_DRIVER_RETURN);
@@ -3925,7 +3945,7 @@ CUresult cuMemFreeAsync(CUdeviceptr dptr, CUstream hStream) {
   CUresult ret;
   CUdevice device;
   int type = get_gpu_virt_memory_type(dptr);
-  if (type == 2) {
+  if (type == MEMORY_TYPE_UVA_ASYNC) {
     // If the memory type is asynchronous UVA memory record, go this branch
     return free_virt_memory_uva_on_stream(dptr, hStream, __CUDA_API_IS_PTSZ);
   }
@@ -3935,7 +3955,7 @@ CUresult cuMemFreeAsync(CUdeviceptr dptr, CUstream hStream) {
   }
   ret = CUDA_ENTRY_CHECK(cuda_library_entry, __CUDA_API_PTSZ(cuMemFreeAsync), dptr, hStream);
   if (likely(ret == CUDA_SUCCESS)) {
-    if (type > 0) {
+    if (type != 0) {
       free_gpu_virt_memory(dptr, get_host_device_index_by_cuda_device(device));
     }
   }
@@ -3947,7 +3967,7 @@ CUresult cuMemFreeAsync_ptsz(CUdeviceptr dptr, CUstream hStream) {
   CUresult ret;
   CUdevice device;
   int type = get_gpu_virt_memory_type(dptr);
-  if (type == 2) {
+  if (type == MEMORY_TYPE_UVA_ASYNC) {
     // If the memory type is asynchronous UVA memory record, go this branch
     return free_virt_memory_uva_on_stream(dptr, hStream, 1);
   }
@@ -3957,7 +3977,7 @@ CUresult cuMemFreeAsync_ptsz(CUdeviceptr dptr, CUstream hStream) {
   }
   ret = CUDA_ENTRY_CHECK(cuda_library_entry, cuMemFreeAsync_ptsz, dptr, hStream);
   if (likely(ret == CUDA_SUCCESS)) {
-    if (type > 0) {
+    if (type != 0) {
       free_gpu_virt_memory(dptr, get_host_device_index_by_cuda_device(device));
     }
   }

--- a/library/src/cuda_originals.c
+++ b/library/src/cuda_originals.c
@@ -3282,68 +3282,88 @@ CUresult cuGraphExecKernelNodeSetParams(CUgraphExec hGraphExec,
 //}
 
 //CUresult _cuStreamGetCaptureInfo(CUstream hStream,
-//                                CUstreamCaptureStatus *captureStatus,
-//                                cuuint64_t *id) {
-//  CUresult ret;
-//  if (likely(CUDA_FIND_ENTRY(cuda_library_entry, __CUDA_API_PTSZ(cuStreamGetCaptureInfo_v2)))) {
+//                                   CUstreamCaptureStatus *captureStatus,
+//                                   cuuint64_t *id, CUgraph *hGraph,
+//                                   const CUgraphNode **dependencies,
+//                                   const CUgraphEdgeData **edgeData,
+//                                   size_t *numDependencies) {
+//  CUresult ret = CUDA_ERROR_NOT_FOUND;
+//  if (likely(CUDA_FIND_ENTRY(cuda_library_entry, __CUDA_API_PTSZ(cuStreamGetCaptureInfo_v3)))) {
+//    ret = CUDA_ENTRY_CHECK(cuda_library_entry, __CUDA_API_PTSZ(cuStreamGetCaptureInfo_v3),
+//                           hStream, captureStatus, id, hGraph, dependencies, edgeData, numDependencies);
+//  } else if (likely(CUDA_FIND_ENTRY(cuda_library_entry, __CUDA_API_PTSZ(cuStreamGetCaptureInfo_v2)))) {
+//    if (edgeData != NULL) *edgeData = NULL;
 //    ret = CUDA_ENTRY_CHECK(cuda_library_entry, __CUDA_API_PTSZ(cuStreamGetCaptureInfo_v2),
-//                                                           hStream, captureStatus, id);
+//                           hStream, captureStatus, id, hGraph, dependencies, numDependencies);
 //  } else if (likely(CUDA_FIND_ENTRY(cuda_library_entry, __CUDA_API_PTSZ(cuStreamGetCaptureInfo)))) {
+//    if (hGraph != NULL) *hGraph = NULL;
+//    if (dependencies != NULL) *dependencies = NULL;
+//    if (edgeData != NULL) *edgeData = NULL;
+//    if (numDependencies != NULL) *numDependencies = NULL;
 //    ret = CUDA_ENTRY_CHECK(cuda_library_entry, __CUDA_API_PTSZ(cuStreamGetCaptureInfo),
-//                                                           hStream, captureStatus, id);
-//  } else {
-//    ret = CUDA_ERROR_NOT_FOUND;
+//                           hStream, captureStatus, id);
 //  }
 //  return ret;
-//}
-//
-//CUresult cuStreamGetCaptureInfo_v2(CUstream hStream,
-//                                   CUstreamCaptureStatus *captureStatus,
-//                                   cuuint64_t *id) {
-//  return _cuStreamGetCaptureInfo(hStream, captureStatus, id);
-//}
-//
-//CUresult cuStreamGetCaptureInfo(CUstream hStream,
-//                                CUstreamCaptureStatus *captureStatus,
-//                                cuuint64_t *id) {
-//  return _cuStreamGetCaptureInfo(hStream, captureStatus, id);
 //}
 
-//CUresult _cuStreamGetCaptureInfo_ptsz(CUstream hStream,
-//                                     CUstreamCaptureStatus *captureStatus,
-//                                     cuuint64_t *id) {
-//  CUresult ret;
-//  if (likely(CUDA_FIND_ENTRY(cuda_library_entry, cuStreamGetCaptureInfo_v2_ptsz))) {
-//    ret = CUDA_ENTRY_CHECK(cuda_library_entry, cuStreamGetCaptureInfo_v2_ptsz,
-//                           hStream, captureStatus, id);
-//  } else if (likely(CUDA_FIND_ENTRY(cuda_library_entry, cuStreamGetCaptureInfo_ptsz))) {
-//    ret = CUDA_ENTRY_CHECK(cuda_library_entry, cuStreamGetCaptureInfo_ptsz,
-//                           hStream, captureStatus, id);
-//  } else {
-//    ret = CUDA_ERROR_NOT_FOUND;
-//  }
-//  return ret;
-//}
-//
-//CUresult cuStreamGetCaptureInfo_v2_ptsz(CUstream hStream,
-//                                        CUstreamCaptureStatus *captureStatus,
-//                                        cuuint64_t *id) {
-//  return _cuStreamGetCaptureInfo_ptsz(hStream, captureStatus, id);
-//}
-//
-//CUresult cuStreamGetCaptureInfo_ptsz(CUstream hStream,
-//                                     CUstreamCaptureStatus *captureStatus,
-//                                     cuuint64_t *id) {
-//  return _cuStreamGetCaptureInfo_ptsz(hStream, captureStatus, id);
-//}
+CUresult cuStreamGetCaptureInfo(CUstream hStream,
+                                CUstreamCaptureStatus *captureStatus,
+                                cuuint64_t *id) {
+  return CUDA_ENTRY_CHECK(cuda_library_entry, __CUDA_API_PTSZ(cuStreamGetCaptureInfo),
+                                    hStream, captureStatus, id);
+}
+
+CUresult cuStreamGetCaptureInfo_ptsz(CUstream hStream,
+                                     CUstreamCaptureStatus *captureStatus,
+                                     cuuint64_t *id) {
+  return CUDA_ENTRY_CHECK(cuda_library_entry, cuStreamGetCaptureInfo_ptsz,
+                                    hStream, captureStatus, id);
+}
+
+CUresult cuStreamGetCaptureInfo_v2(CUstream hStream,
+                                   CUstreamCaptureStatus *captureStatus,
+                                   cuuint64_t *id, CUgraph *hGraph,
+                                   const CUgraphNode **dependencies,
+                                   size_t *numDependencies) {
+  return CUDA_ENTRY_CHECK_STRICT(cuda_library_entry, __CUDA_API_PTSZ(cuStreamGetCaptureInfo_v2),
+                          hStream, captureStatus, id, hGraph, dependencies, numDependencies);
+}
+
+CUresult cuStreamGetCaptureInfo_v2_ptsz(CUstream hStream,
+                                        CUstreamCaptureStatus *captureStatus,
+                                        cuuint64_t *id, CUgraph *hGraph,
+                                        const CUgraphNode **dependencies,
+                                        size_t *numDependencies) {
+  return CUDA_ENTRY_CHECK_STRICT(cuda_library_entry, cuStreamGetCaptureInfo_v2_ptsz,
+                          hStream, captureStatus, id, hGraph, dependencies, numDependencies);
+}
+
+CUresult cuStreamGetCaptureInfo_v3(CUstream hStream,
+                                   CUstreamCaptureStatus *captureStatus,
+                                   cuuint64_t *id, CUgraph *hGraph,
+                                   const CUgraphNode **dependencies,
+                                   const CUgraphEdgeData **edgeData,
+                                   size_t *numDependencies) {
+  return CUDA_ENTRY_CHECK_STRICT(cuda_library_entry, __CUDA_API_PTSZ(cuStreamGetCaptureInfo_v3),
+                          hStream, captureStatus, id, hGraph, dependencies, edgeData, numDependencies);
+}
+
+CUresult cuStreamGetCaptureInfo_v3_ptsz(CUstream hStream,
+                                   CUstreamCaptureStatus *captureStatus,
+                                   cuuint64_t *id, CUgraph *hGraph,
+                                   const CUgraphNode **dependencies,
+                                   const CUgraphEdgeData **edgeData,
+                                   size_t *numDependencies) {
+  return CUDA_ENTRY_CHECK_STRICT(cuda_library_entry, cuStreamGetCaptureInfo_v3_ptsz,
+                          hStream, captureStatus, id, hGraph, dependencies, edgeData, numDependencies);
+}
 
 CUresult cuThreadExchangeStreamCaptureMode(CUstreamCaptureMode *mode) {
   return CUDA_ENTRY_CHECK(cuda_library_entry, cuThreadExchangeStreamCaptureMode,
                          mode);
 }
 
-CUresult cuDeviceGetNvSciSyncAttributes(void *nvSciSyncAttrList, CUdevice dev,
-                                        int flags) {
+CUresult cuDeviceGetNvSciSyncAttributes(void *nvSciSyncAttrList, CUdevice dev, int flags) {
   return CUDA_ENTRY_CHECK(cuda_library_entry, cuDeviceGetNvSciSyncAttributes,
                          nvSciSyncAttrList, dev, flags);
 }
@@ -3874,6 +3894,22 @@ CUresult cuMemGetHandleForAddressRange(void *handle, CUdeviceptr dptr, size_t si
   return CUDA_ENTRY_CHECK(cuda_library_entry, cuMemGetHandleForAddressRange, handle,
                           dptr, size, handleType, flags);
 }
+
+//CUresult _cuGraphAddNode(CUgraphNode* phGraphNode, CUgraph hGraph,
+//                           const CUgraphNode* dependencies, const CUgraphEdgeData* dependencyData,
+//                           size_t numDependencies, CUgraphNodeParams* nodeParams) {
+//  CUresult ret = CUDA_ERROR_NOT_FOUND;
+//  if (likely(CUDA_FIND_ENTRY(cuda_library_entry, cuGraphAddNode_v2))) {
+//    ret = CUDA_ENTRY_CHECK(cuda_library_entry, cuGraphAddNode_v2, phGraphNode, hGraph,
+//                             dependencies, dependencyData, numDependencies, nodeParams);
+//  } else if (likely(CUDA_FIND_ENTRY(cuda_library_entry, cuGraphAddNode))) {
+//    if (dependencyData != NULL) *dependencyData = NULL;
+//    ret = CUDA_ENTRY_CHECK(cuda_library_entry, cuGraphAddNode, phGraphNode, hGraph,
+//                             dependencies, numDependencies, nodeParams);
+//  }
+//  return ret;
+//}
+
 
 CUresult cuGraphAddNode_v2(CUgraphNode* phGraphNode, CUgraph hGraph,
                            const CUgraphNode* dependencies, const CUgraphEdgeData* dependencyData,

--- a/library/src/cuda_originals.c
+++ b/library/src/cuda_originals.c
@@ -2905,9 +2905,8 @@ CUresult cuGraphCreate(CUgraph *phGraph, unsigned int flags) {
   return CUDA_ENTRY_CHECK(cuda_library_entry, cuGraphCreate, phGraph, flags);
 }
 
-CUresult cuGraphDestroy(CUgraph hGraph) {
-  return CUDA_ENTRY_CHECK(cuda_library_entry, cuGraphDestroy, hGraph);
-}
+/* cuGraphDestroy is hooked in cuda_hook.c: destroying the graph is the second
+ * point at which a capture charge has to come off. */
 
 CUresult cuGraphDestroyNode(CUgraphNode hNode) {
   return CUDA_ENTRY_CHECK(cuda_library_entry, cuGraphDestroyNode, hNode);

--- a/library/src/cuda_originals.c
+++ b/library/src/cuda_originals.c
@@ -369,28 +369,6 @@ CUresult cuMemHostGetFlags(unsigned int *pFlags, void *p) {
   return CUDA_ENTRY_CHECK(cuda_library_entry, cuMemHostGetFlags, pFlags, p);
 }
 
-CUresult _cuMemHostRegister(void *p, size_t bytesize, unsigned int Flags) {
-  CUresult ret;
-  if (likely(CUDA_FIND_ENTRY(cuda_library_entry, cuMemHostRegister_v2))) {
-    ret = CUDA_ENTRY_CHECK(cuda_library_entry, cuMemHostRegister_v2,
-                           p, bytesize, Flags);
-  } else if (likely(CUDA_FIND_ENTRY(cuda_library_entry, cuMemHostRegister))) {
-    ret = CUDA_ENTRY_CHECK(cuda_library_entry, cuMemHostRegister,
-                           p, bytesize, Flags);
-  } else {
-    ret = CUDA_ERROR_NOT_FOUND;
-  }
-  return ret;
-}
-
-CUresult cuMemHostRegister_v2(void *p, size_t bytesize, unsigned int Flags) {
-  return _cuMemHostRegister(p, bytesize, Flags);
-}
-
-CUresult cuMemHostRegister(void *p, size_t bytesize, unsigned int Flags) {
-  return _cuMemHostRegister(p, bytesize, Flags);
-}
-
 CUresult cuMemHostUnregister(void *p) {
   return CUDA_ENTRY_CHECK(cuda_library_entry, cuMemHostUnregister, p);
 }

--- a/library/src/cuda_originals.c
+++ b/library/src/cuda_originals.c
@@ -338,11 +338,6 @@ CUresult cuMemFreeHost(void *p) {
   return CUDA_ENTRY_CHECK(cuda_library_entry, cuMemFreeHost, p);
 }
 
-CUresult cuMemHostAlloc(void **pp, size_t bytesize, unsigned int Flags) {
-  return CUDA_ENTRY_CHECK(cuda_library_entry, cuMemHostAlloc, pp, bytesize,
-                         Flags);
-}
-
 CUresult _cuMemHostGetDevicePointer(CUdeviceptr *pdptr, void *p, unsigned int Flags) {
   CUresult ret;
   if (likely(CUDA_FIND_ENTRY(cuda_library_entry, cuMemHostGetDevicePointer_v2))) {

--- a/library/src/loader.c
+++ b/library/src/loader.c
@@ -1860,34 +1860,52 @@ void reset_cuda_index_mapping() {
 }
 
 void malloc_gpu_virt_memory(CUdeviceptr dptr, size_t bytes, int type, int host_index) {
-  memory_node_t *new_node = NULL;
-  new_node = (memory_node_t*) malloc(sizeof(memory_node_t));
-  if (unlikely(!new_node)) {
-    LOGGER(ERROR, "failed to allocate virt memory node");
-    return;
-  }
-
-  new_node->dptr = dptr;
-  new_node->bytes = bytes;
-  new_node->type = type;
-  INIT_LIST_HEAD(&new_node->node);
+  int found = 0;
+  memory_node_t *entry_tmp = NULL;
+  struct list_head *iter;
+  size_t old_bytes = 0;
 
   pthread_mutex_lock(&g_memory_node_lock);
-  list_add(&new_node->node, &g_memory_node->node);
+  list_for_each(iter, &g_memory_node->node) {
+    entry_tmp = container_of(iter, memory_node_t, node);
+    if (entry_tmp != NULL && entry_tmp->dptr == dptr) {
+      old_bytes = entry_tmp->bytes;
+      entry_tmp->bytes = bytes;
+      entry_tmp->type = type;
+      found = 1;
+      break;
+    }
+  }
+  if (!found) {
+    memory_node_t *new_node = (memory_node_t *)malloc(sizeof(memory_node_t));
+    if (unlikely(!new_node)) {
+      pthread_mutex_unlock(&g_memory_node_lock);
+      LOGGER(ERROR, "failed to allocate virt memory node");
+      return;
+    }
+    new_node->dptr = dptr;
+    new_node->bytes = bytes;
+    new_node->type = type;
+    INIT_LIST_HEAD(&new_node->node);
+    list_add(&new_node->node, &g_memory_node->node);
+  }
   pthread_mutex_unlock(&g_memory_node_lock);
 
   if (host_index < 0 || host_index >= MAX_DEVICE_COUNT) return;
   LOGGER(VERBOSE, "malloc virt memory to host device %d, dptr %lld, size %ld", host_index, dptr, bytes);
 
+  // Calculate increment
+  ssize_t delta = found ? (ssize_t)(bytes - old_bytes) : (ssize_t)bytes;
+
   if (g_device_vmem != NULL) {
     int fd = device_vmem_write_lock(host_index);
     if (fd < 0) return;
     int pid = getpid();
-    int found = 0;
+    found = 0;
     unsigned int processes_size = g_device_vmem->devices[host_index].processes_size;
     for (int i = 0; i < processes_size; i++) {
       if (g_device_vmem->devices[host_index].processes[i].pid == pid) {
-        g_device_vmem->devices[host_index].processes[i].used += bytes;
+        g_device_vmem->devices[host_index].processes[i].used += delta;
         found = 1;
         break;
       }
@@ -1899,7 +1917,7 @@ void malloc_gpu_virt_memory(CUdeviceptr dptr, size_t bytes, int type, int host_i
         return;
       }
       g_device_vmem->devices[host_index].processes[processes_size].pid = pid;
-      g_device_vmem->devices[host_index].processes[processes_size].used = bytes;
+      g_device_vmem->devices[host_index].processes[processes_size].used = (delta > 0) ? delta : 0;
       g_device_vmem->devices[host_index].processes_size++;
     }
     device_vmem_unlock(fd, host_index);

--- a/library/src/loader.c
+++ b/library/src/loader.c
@@ -2041,8 +2041,16 @@ int get_gpu_virt_memory_type(CUdeviceptr dptr) {
   return type;
 }
 
-void free_gpu_virt_memory(CUdeviceptr dptr, int host_index) {
+/* Retire the record for dptr, discharging whatever it was charged.
+ *
+ * The device comes from the record, not from the caller and not from the
+ * current context: a charge and its discharge must land on the same account.
+ * Deriving it at free time instead lets a context switch between allocation and
+ * free (or a cuCtxGetDevice that no longer works) credit the wrong device,
+ * leaving one understated and another overstated for the life of the process. */
+void free_gpu_virt_memory(CUdeviceptr dptr) {
   int found = 0;
+  int host_index = -1;
   memory_node_t *entry_tmp = NULL;
   struct list_head *iter;
   size_t size = 0;
@@ -2053,6 +2061,7 @@ void free_gpu_virt_memory(CUdeviceptr dptr, int host_index) {
     if (entry_tmp->dptr == dptr) {
       found = 1;
       size = entry_tmp->bytes;
+      host_index = entry_tmp->host_index;
       list_del(&entry_tmp->node);
       free(entry_tmp);
       break;
@@ -2384,6 +2393,32 @@ void loader_child_after_fork(void) {
   pthread_mutex_init(&init_config_mutex,  NULL);
   memset(tid_dlsyms, 0, sizeof(tid_dlsyms));
   tid_dlsym_count = 0;
+
+  /* Drop the inherited virtual-memory records. Every one of them describes an
+   * allocation of the PARENT: CUDA contexts do not survive fork, so none of the
+   * pointers or graph handles mean anything here, and the charges they stand for
+   * sit in the shared counter under the parent's pid, where they still belong.
+   *
+   * Keeping them is actively harmful once the child starts allocating, because
+   * the driver reuses addresses: a new dptr landing on a stale record makes
+   * malloc_gpu_virt_memory() charge the difference against a phantom size, a new
+   * CUgraph landing on a stale one makes free_gpu_virt_memory_by_graph() retire
+   * records it does not own, and get_gpu_virt_memory_type() can report a plain
+   * pointer as oversold UVA and send cuMemFreeAsync down the cuMemFree path.
+   * graph_cost_after_fork() wipes its cache for exactly this reason.
+   *
+   * Freeing (rather than just re-heading the list) matters because forked
+   * workers commonly run long without exec. glibc resets the malloc lock in the
+   * child via its own atfork handlers, so free() here is safe -- and this
+   * library is glibc-only by construction (see the toolchain gate in hook.h). */
+  memory_node_t *entry_tmp = NULL;
+  struct list_head *iter, *tmp;
+  list_for_each_safe(iter, tmp, &g_memory_node->node) {
+    entry_tmp = container_of(iter, memory_node_t, node);
+    list_del(iter);
+    free(entry_tmp);
+  }
+  INIT_LIST_HEAD(&g_memory_node->node);
 }
 
 /* fork() child handler implemented in cuda_hook.c. Registered lazily

--- a/library/src/loader.c
+++ b/library/src/loader.c
@@ -464,8 +464,8 @@ entry_t cuda_library_entry[] = {
     {.name = "cuSignalExternalSemaphoresAsync_ptsz"},
 //    {.name = "cuStreamBeginCapture"},
 //    {.name = "cuStreamBeginCapture_ptsz"},
-//    {.name = "cuStreamEndCapture"},
-//    {.name = "cuStreamEndCapture_ptsz"},
+    {.name = "cuStreamEndCapture"},
+    {.name = "cuStreamEndCapture_ptsz"},
     {.name = "cuStreamGetCtx"},
     {.name = "cuStreamGetCtx_v2"},
     {.name = "cuStreamGetCtx_ptsz"},
@@ -1876,11 +1876,14 @@ void reset_cuda_index_mapping() {
   pthread_mutex_unlock(&device_index_mutex);
 }
 
-void malloc_gpu_virt_memory(CUdeviceptr dptr, size_t bytes, int type, int host_index) {
+static void malloc_gpu_virt_memory_graph(CUdeviceptr dptr, size_t bytes, int type,
+                                         CUgraph graph, int host_index) {
   int found = 0;
   memory_node_t *entry_tmp = NULL;
   struct list_head *iter;
   size_t old_bytes = 0;
+
+  int charged = (host_index >= 0 && host_index < MAX_DEVICE_COUNT) ? host_index : -1;
 
   pthread_mutex_lock(&g_memory_node_lock);
   list_for_each(iter, &g_memory_node->node) {
@@ -1889,6 +1892,8 @@ void malloc_gpu_virt_memory(CUdeviceptr dptr, size_t bytes, int type, int host_i
       old_bytes = entry_tmp->bytes;
       entry_tmp->bytes = bytes;
       entry_tmp->type = type;
+      entry_tmp->graph = graph;
+      entry_tmp->host_index = charged;
       found = 1;
       break;
     }
@@ -1903,6 +1908,8 @@ void malloc_gpu_virt_memory(CUdeviceptr dptr, size_t bytes, int type, int host_i
     new_node->dptr = dptr;
     new_node->bytes = bytes;
     new_node->type = type;
+    new_node->graph = graph;
+    new_node->host_index = charged;
     INIT_LIST_HEAD(&new_node->node);
     list_add(&new_node->node, &g_memory_node->node);
   }
@@ -1948,6 +1955,72 @@ void malloc_gpu_virt_memory(CUdeviceptr dptr, size_t bytes, int type, int host_i
       g_device_vmem->devices[host_index].processes_size++;
     }
     device_vmem_unlock(fd, host_index);
+  }
+}
+
+void malloc_gpu_virt_memory(CUdeviceptr dptr, size_t bytes, int type, int host_index) {
+  malloc_gpu_virt_memory_graph(dptr, bytes, type, NULL, host_index);
+}
+
+void malloc_gpu_virt_memory_captured(CUdeviceptr dptr, size_t bytes,
+                                     CUgraph graph, int host_index) {
+  malloc_gpu_virt_memory_graph(dptr, bytes, MEMORY_TYPE_CAPTURE, graph, host_index);
+}
+
+/* Discharge every capture record owned by graph.
+ *
+ * Each record is discharged against the device recorded when it was charged,
+ * never against a device looked up here: this runs from cuStreamEndCapture,
+ * where the context may already be unusable, and a discharge that gives up
+ * after the nodes are dropped would strand the charge in the shared counter
+ * permanently -- exactly the false-OOM this accounting exists to avoid.
+ *
+ * Nodes are detached under the list mutex first and the shared counter is
+ * updated afterwards, because that update takes the cross-process vmem lock and
+ * must not nest inside the list mutex (free_gpu_virt_memory() orders them the
+ * same way). */
+void free_gpu_virt_memory_by_graph(CUgraph graph) {
+  size_t totals[MAX_DEVICE_COUNT] = {0};
+  memory_node_t *entry_tmp = NULL;
+  struct list_head *iter, *tmp;
+  int any = 0;
+
+  if (graph == NULL) return;
+
+  pthread_mutex_lock(&g_memory_node_lock);
+  list_for_each_safe(iter, tmp, &g_memory_node->node) {
+    entry_tmp = container_of(iter, memory_node_t, node);
+    if (entry_tmp == NULL) continue;
+    if (entry_tmp->type == MEMORY_TYPE_CAPTURE && entry_tmp->graph == graph) {
+      int idx = entry_tmp->host_index;
+      if (idx >= 0 && idx < MAX_DEVICE_COUNT) {
+        totals[idx] += entry_tmp->bytes;
+        any = 1;
+      }
+      list_del(&entry_tmp->node);
+      free(entry_tmp);
+    }
+  }
+  pthread_mutex_unlock(&g_memory_node_lock);
+
+  if (!any || g_device_vmem == NULL) return;
+
+  for (int dev = 0; dev < MAX_DEVICE_COUNT; dev++) {
+    if (totals[dev] == 0) continue;
+    LOGGER(VERBOSE, "free captured virt memory to host device %d, graph %p, size %zu",
+           dev, (void *)graph, totals[dev]);
+    int fd = device_vmem_write_lock(dev);
+    if (fd < 0) continue;
+    int pid = getpid();
+    for (int i = 0; i < g_device_vmem->devices[dev].processes_size; i++) {
+      if (g_device_vmem->devices[dev].processes[i].pid == pid) {
+        size_t cur = g_device_vmem->devices[dev].processes[i].used;
+        g_device_vmem->devices[dev].processes[i].used =
+            (cur >= totals[dev]) ? (cur - totals[dev]) : 0;
+        break;
+      }
+    }
+    device_vmem_unlock(fd, dev);
   }
 }
 

--- a/library/src/loader.c
+++ b/library/src/loader.c
@@ -1859,7 +1859,7 @@ void reset_cuda_index_mapping() {
   pthread_mutex_unlock(&device_index_mutex);
 }
 
-void malloc_gpu_virt_memory(CUdeviceptr dptr, size_t bytes, int host_index) {
+void malloc_gpu_virt_memory(CUdeviceptr dptr, size_t bytes, int type, int host_index) {
   memory_node_t *new_node = NULL;
   new_node = (memory_node_t*) malloc(sizeof(memory_node_t));
   if (unlikely(!new_node)) {
@@ -1869,6 +1869,7 @@ void malloc_gpu_virt_memory(CUdeviceptr dptr, size_t bytes, int host_index) {
 
   new_node->dptr = dptr;
   new_node->bytes = bytes;
+  new_node->type = type;
   INIT_LIST_HEAD(&new_node->node);
 
   pthread_mutex_lock(&g_memory_node_lock);
@@ -1905,12 +1906,8 @@ void malloc_gpu_virt_memory(CUdeviceptr dptr, size_t bytes, int host_index) {
   }
 }
 
-/* Reports whether dptr was handed out by the oversold UVA fallback, i.e. it
- * came from cuMemAllocManaged rather than the allocator the caller asked for.
- * Such a pointer is only valid for the synchronous cuMemFree; the driver's
- * cuMemFreeAsync rejects it. */
-int is_gpu_virt_memory(CUdeviceptr dptr) {
-  int found = 0;
+int get_gpu_virt_memory_type(CUdeviceptr dptr) {
+  int type = 0;
   memory_node_t *entry_tmp = NULL;
   struct list_head *iter;
   pthread_mutex_lock(&g_memory_node_lock);
@@ -1918,12 +1915,12 @@ int is_gpu_virt_memory(CUdeviceptr dptr) {
     entry_tmp = container_of(iter, memory_node_t, node);
     if (entry_tmp == NULL) continue;
     if (entry_tmp->dptr == dptr) {
-      found = 1;
+      type = entry_tmp->type;
       break;
     }
   }
   pthread_mutex_unlock(&g_memory_node_lock);
-  return found;
+  return type;
 }
 
 void free_gpu_virt_memory(CUdeviceptr dptr, int host_index) {

--- a/library/src/loader.c
+++ b/library/src/loader.c
@@ -478,8 +478,8 @@ entry_t cuda_library_entry[] = {
     {.name = "cuGraphExecKernelNodeSetParams"},
 //    {.name = "cuStreamBeginCapture_v2"},
 //    {.name = "cuStreamBeginCapture_v2_ptsz"},
-//    {.name = "cuStreamGetCaptureInfo"},
-//    {.name = "cuStreamGetCaptureInfo_ptsz"},
+    {.name = "cuStreamGetCaptureInfo"},
+    {.name = "cuStreamGetCaptureInfo_ptsz"},
     {.name = "cuThreadExchangeStreamCaptureMode"},
     {.name = "cuDeviceGetNvSciSyncAttributes"},
     {.name = "cuGraphExecHostNodeSetParams"},
@@ -584,8 +584,10 @@ entry_t cuda_library_entry[] = {
     {.name = "cuGraphMemFreeNodeGetParams"},
     {.name = "cuGraphReleaseUserObject"},
     {.name = "cuGraphRetainUserObject"},
-//    {.name = "cuStreamGetCaptureInfo_v2"},
-//    {.name = "cuStreamGetCaptureInfo_v2_ptsz"},
+    {.name = "cuStreamGetCaptureInfo_v2"},
+    {.name = "cuStreamGetCaptureInfo_v2_ptsz"},
+    {.name = "cuStreamGetCaptureInfo_v3"},
+    {.name = "cuStreamGetCaptureInfo_v3_ptsz"},
     {.name = "cuStreamUpdateCaptureDependencies"},
     {.name = "cuStreamUpdateCaptureDependencies_ptsz"},
     {.name = "cuUserObjectCreate"},
@@ -1688,6 +1690,21 @@ static void signal_cleanup_handler_sa(int signum, siginfo_t *info, void *ucontex
   raise(signum);
 }
 
+// Cleaning up invalid virtual memory nodes on the device.
+void check_cleanup_vmem_nodes_by_device(int host_index) {
+  if (host_index < 0 || host_index >= MAX_DEVICE_COUNT) return;
+  if (g_device_vmem != NULL) {
+    if (g_device_vmem->devices[host_index].processes_size == 0) {
+      return;
+    }
+    int fd = device_vmem_write_lock(host_index);
+    if (fd < 0) return;
+    rm_vmem_node_by_non_existent_device_pid(host_index, -1);
+//    __sync_synchronize();
+    device_vmem_unlock(fd, host_index);
+  }
+}
+
 // check and clean up any unreleased virtual memory records.
 void check_cleanup_vmem_nodes() {
   if (g_device_vmem != NULL) {
@@ -1993,6 +2010,7 @@ void free_gpu_virt_memory(CUdeviceptr dptr, int host_index) {
 void get_used_gpu_virt_memory(void *arg, int host_index) {
   size_t count = 0;
   size_t *used_memory = arg;
+  if (host_index < 0 || host_index >= MAX_DEVICE_COUNT) goto DONE;
   if (g_vgpu_config->vmem_node && g_device_vmem != NULL) {
     int fd = device_vmem_read_lock(host_index);
     if (fd < 0) goto DONE;

--- a/library/src/loader.c
+++ b/library/src/loader.c
@@ -1894,8 +1894,11 @@ void malloc_gpu_virt_memory(CUdeviceptr dptr, size_t bytes, int type, int host_i
   if (host_index < 0 || host_index >= MAX_DEVICE_COUNT) return;
   LOGGER(VERBOSE, "malloc virt memory to host device %d, dptr %lld, size %ld", host_index, dptr, bytes);
 
-  // Calculate increment
-  ssize_t delta = found ? (ssize_t)(bytes - old_bytes) : (ssize_t)bytes;
+  /* Calculate increment. Re-recording a known dptr with a smaller size yields a
+   * NEGATIVE delta, so the shared counter has to be adjusted with the same
+   * saturation free_gpu_virt_memory() applies: `used` is size_t, and letting it
+   * wrap would leave a ~2^64 usage that fails every later allocation. */
+  ssize_t delta = found ? (ssize_t)bytes - (ssize_t)old_bytes : (ssize_t)bytes;
 
   if (g_device_vmem != NULL) {
     int fd = device_vmem_write_lock(host_index);
@@ -1905,7 +1908,14 @@ void malloc_gpu_virt_memory(CUdeviceptr dptr, size_t bytes, int type, int host_i
     unsigned int processes_size = g_device_vmem->devices[host_index].processes_size;
     for (int i = 0; i < processes_size; i++) {
       if (g_device_vmem->devices[host_index].processes[i].pid == pid) {
-        g_device_vmem->devices[host_index].processes[i].used += delta;
+        size_t cur = g_device_vmem->devices[host_index].processes[i].used;
+        if (delta >= 0) {
+          g_device_vmem->devices[host_index].processes[i].used = cur + (size_t)delta;
+        } else {
+          size_t dec = (size_t)(-delta);
+          g_device_vmem->devices[host_index].processes[i].used =
+              (cur >= dec) ? (cur - dec) : 0;
+        }
         found = 1;
         break;
       }

--- a/library/test/CMakeLists.txt
+++ b/library/test/CMakeLists.txt
@@ -90,6 +90,18 @@ if(EXISTS ${_POOL_ASYNC_SRC})
     vgpu_configure_c_test(test_alloc_pool_async_ptsz)
 endif()
 
+# Same reason: without this variant the _ptsz copies of the async allocation
+# hooks are never executed, so a defect introduced in one of them passes every
+# test. (Verified the hard way -- commenting the accounting out of
+# cuMemAllocAsync_ptsz left the suite green.)
+set(_ASYNC_ACCT_SRC ${TEST_SRC_DIR}/test_alloc_async_accounting.c)
+if(EXISTS ${_ASYNC_ACCT_SRC})
+    add_executable(test_alloc_async_accounting_ptsz ${_ASYNC_ACCT_SRC})
+    target_compile_definitions(test_alloc_async_accounting_ptsz
+                               PRIVATE CUDA_API_PER_THREAD_DEFAULT_STREAM)
+    vgpu_configure_c_test(test_alloc_async_accounting_ptsz)
+endif()
+
 # ---- CUDA tests (kernel launches) -----------------------------------------
 file(GLOB CU_TESTS "${TEST_SRC_DIR}/test_*.cu")
 if(CU_TESTS)

--- a/library/test/run_all_tests.sh
+++ b/library/test/run_all_tests.sh
@@ -45,15 +45,12 @@ export TEST_DEVICE_ID="${TEST_DEVICE_ID:-0}"
 #            (rc=77). Those preconditions -- LD_PRELOAD, the vmem ledger -- are
 #            things this harness is supposed to provide, so a skip here means
 #            the setup is wrong and the assertions silently did not run.
-#   ABSENT   an optional dependency is not installed (no torch, no tensorflow).
-#            Nothing is misconfigured; there is simply nothing to run against.
 #
 # Keeping them apart is what lets VGPU_TEST_STRICT fail on the first without
 # also failing every machine that happens not to have a framework installed.
-declare -i TOTAL=0 PASSED=0 FAILED=0 SKIPPED=0 ABSENT=0
+declare -i TOTAL=0 PASSED=0 FAILED=0 SKIPPED=0
 FAILED_NAMES=()
 SKIPPED_NAMES=()
-ABSENT_NAMES=()
 
 # Exit status a test uses to say "I did not actually run" (the autotools
 # convention). A test whose preconditions were not met must NOT report success:
@@ -115,9 +112,9 @@ if [[ "${SKIP_PYTHON:-0}" == "0" && -d "${PY_DIR}" ]]; then
       *)                     mod= ;;
     esac
     if [[ -n "${mod}" ]] && ! python3 -c "import ${mod}" >/dev/null 2>&1; then
-      printf "=== %-36s ABSENT (module '%s' not installed)\n" "${name}" "${mod}"
-      ABSENT=$((ABSENT + 1))
-      ABSENT_NAMES+=("${name} (no ${mod})")
+      printf "=== %-36s SKIP (module '%s' not installed)\n" "${name}" "${mod}"
+      SKIPPED=$((SKIPPED + 1))
+      SKIPPED_NAMES+=("${name} (no ${mod})")
       continue
     fi
     run_one "${name}" env LD_PRELOAD="${VGPU_SO}" python3 "${py}" \
@@ -127,11 +124,7 @@ fi
 
 echo
 echo "============================================================"
-echo "Summary: total=${TOTAL} pass=${PASSED} fail=${FAILED} skip=${SKIPPED} absent=${ABSENT}"
-if (( ABSENT > 0 )); then
-  echo "Not runnable here (optional dependency missing):"
-  for n in "${ABSENT_NAMES[@]}"; do echo "  - ${n}"; done
-fi
+echo "Summary: total=${TOTAL} pass=${PASSED} fail=${FAILED} skip=${SKIPPED}"
 if (( FAILED > 0 )); then
   echo "Failed tests:"
   for n in "${FAILED_NAMES[@]}"; do echo "  - ${n}"; done
@@ -143,8 +136,7 @@ if (( SKIPPED > 0 )); then
   # These preconditions are ours to provide, so a skip means the harness did
   # not deliver what the test was promised and a green result would overstate
   # what was verified. run_tests_with_env.sh sets everything up and turns this
-  # on. Absent optional dependencies are deliberately NOT counted here: nothing
-  # is misconfigured when a machine simply has no torch installed.
+  # on.
   if [[ "${VGPU_TEST_STRICT:-0}" != "0" ]]; then
     echo "[FAIL] VGPU_TEST_STRICT is set: these tests were expected to run."
     exit 1

--- a/library/test/run_all_tests.sh
+++ b/library/test/run_all_tests.sh
@@ -39,9 +39,21 @@ fi
 TEST_TIMEOUT="${TEST_TIMEOUT:-120}"
 export TEST_DEVICE_ID="${TEST_DEVICE_ID:-0}"
 
-declare -i TOTAL=0 PASSED=0 FAILED=0 SKIPPED=0
+# Two different things get called "skipped", and only one of them is a problem:
+#
+#   SKIPPED  a test ran and reported that its own preconditions were not met
+#            (rc=77). Those preconditions -- LD_PRELOAD, the vmem ledger -- are
+#            things this harness is supposed to provide, so a skip here means
+#            the setup is wrong and the assertions silently did not run.
+#   ABSENT   an optional dependency is not installed (no torch, no tensorflow).
+#            Nothing is misconfigured; there is simply nothing to run against.
+#
+# Keeping them apart is what lets VGPU_TEST_STRICT fail on the first without
+# also failing every machine that happens not to have a framework installed.
+declare -i TOTAL=0 PASSED=0 FAILED=0 SKIPPED=0 ABSENT=0
 FAILED_NAMES=()
 SKIPPED_NAMES=()
+ABSENT_NAMES=()
 
 # Exit status a test uses to say "I did not actually run" (the autotools
 # convention). A test whose preconditions were not met must NOT report success:
@@ -103,8 +115,9 @@ if [[ "${SKIP_PYTHON:-0}" == "0" && -d "${PY_DIR}" ]]; then
       *)                     mod= ;;
     esac
     if [[ -n "${mod}" ]] && ! python3 -c "import ${mod}" >/dev/null 2>&1; then
-      printf "=== %-36s SKIP (module '%s' not installed)\n" "${name}" "${mod}"
-      SKIPPED=$((SKIPPED + 1))
+      printf "=== %-36s ABSENT (module '%s' not installed)\n" "${name}" "${mod}"
+      ABSENT=$((ABSENT + 1))
+      ABSENT_NAMES+=("${name} (no ${mod})")
       continue
     fi
     run_one "${name}" env LD_PRELOAD="${VGPU_SO}" python3 "${py}" \
@@ -114,22 +127,26 @@ fi
 
 echo
 echo "============================================================"
-echo "Summary: total=${TOTAL} pass=${PASSED} fail=${FAILED} skip=${SKIPPED}"
+echo "Summary: total=${TOTAL} pass=${PASSED} fail=${FAILED} skip=${SKIPPED} absent=${ABSENT}"
+if (( ABSENT > 0 )); then
+  echo "Not runnable here (optional dependency missing):"
+  for n in "${ABSENT_NAMES[@]}"; do echo "  - ${n}"; done
+fi
 if (( FAILED > 0 )); then
   echo "Failed tests:"
   for n in "${FAILED_NAMES[@]}"; do echo "  - ${n}"; done
   exit 1
 fi
 if (( SKIPPED > 0 )); then
-  echo "Skipped tests:"
+  echo "Skipped tests (preconditions not met -- assertions did NOT run):"
   for n in "${SKIPPED_NAMES[@]}"; do echo "  - ${n}"; done
-  # A skip means the assertions never ran, so a green result would be a lie
-  # about what was verified. run_tests_with_env.sh sets up everything the
-  # tests need and turns this on, so a skip there is a misconfiguration, not
-  # an acceptable outcome. Left off for ad-hoc runs where skipping (no GPU,
-  # no framework installed) is legitimate.
+  # These preconditions are ours to provide, so a skip means the harness did
+  # not deliver what the test was promised and a green result would overstate
+  # what was verified. run_tests_with_env.sh sets everything up and turns this
+  # on. Absent optional dependencies are deliberately NOT counted here: nothing
+  # is misconfigured when a machine simply has no torch installed.
   if [[ "${VGPU_TEST_STRICT:-0}" != "0" ]]; then
-    echo "[FAIL] VGPU_TEST_STRICT is set: skipped tests are not acceptable here."
+    echo "[FAIL] VGPU_TEST_STRICT is set: these tests were expected to run."
     exit 1
   fi
 fi

--- a/library/test/run_all_tests.sh
+++ b/library/test/run_all_tests.sh
@@ -41,6 +41,13 @@ export TEST_DEVICE_ID="${TEST_DEVICE_ID:-0}"
 
 declare -i TOTAL=0 PASSED=0 FAILED=0 SKIPPED=0
 FAILED_NAMES=()
+SKIPPED_NAMES=()
+
+# Exit status a test uses to say "I did not actually run" (the autotools
+# convention). A test whose preconditions were not met must NOT report success:
+# a green run would then be indistinguishable from one where the assertions
+# never executed, which is how a real regression slips through unnoticed.
+readonly RC_SKIP=77
 
 run_one() {
   local name="$1"; shift
@@ -53,6 +60,16 @@ run_one() {
     PASSED=$((PASSED + 1))
   else
     local rc=$?
+    if (( rc == RC_SKIP )); then
+      echo "SKIP"
+      SKIPPED=$((SKIPPED + 1))
+      SKIPPED_NAMES+=("${name}")
+      echo "------- output -------"
+      tail -30 "${log}" | sed 's/^/  /'
+      echo "----------------------"
+      rm -f "${log}"
+      return 0
+    fi
     echo "FAIL (rc=${rc})"
     FAILED=$((FAILED + 1))
     FAILED_NAMES+=("${name}")
@@ -102,5 +119,18 @@ if (( FAILED > 0 )); then
   echo "Failed tests:"
   for n in "${FAILED_NAMES[@]}"; do echo "  - ${n}"; done
   exit 1
+fi
+if (( SKIPPED > 0 )); then
+  echo "Skipped tests:"
+  for n in "${SKIPPED_NAMES[@]}"; do echo "  - ${n}"; done
+  # A skip means the assertions never ran, so a green result would be a lie
+  # about what was verified. run_tests_with_env.sh sets up everything the
+  # tests need and turns this on, so a skip there is a misconfiguration, not
+  # an acceptable outcome. Left off for ad-hoc runs where skipping (no GPU,
+  # no framework installed) is legitimate.
+  if [[ "${VGPU_TEST_STRICT:-0}" != "0" ]]; then
+    echo "[FAIL] VGPU_TEST_STRICT is set: skipped tests are not acceptable here."
+    exit 1
+  fi
 fi
 exit 0

--- a/library/test/run_tests_with_env.sh
+++ b/library/test/run_tests_with_env.sh
@@ -41,9 +41,13 @@ export CUDA_CORE_LIMIT=30
 export CUDA_MEM_LIMIT=2048m
 # Turn on the virtual-memory ledger. The limit check only consults it when this
 # is set, and the graph-capture accounting in test_alloc_async_accounting lives
-# entirely in that ledger -- with it off those cases have nothing to assert and
-# report SKIP.
+# entirely in that ledger -- with it off those cases have nothing to assert.
 export VMEMORY_NODE_ENABLED=1
+
+# Everything the tests need is configured above, so a test that reports SKIP
+# here did not find what it was promised: treat that as a failure rather than
+# letting a green summary hide assertions that never ran.
+export VGPU_TEST_STRICT=1
 
 rm -f /etc/vgpu-manager/config/vgpu.config
 

--- a/library/test/run_tests_with_env.sh
+++ b/library/test/run_tests_with_env.sh
@@ -47,7 +47,7 @@ export VMEMORY_NODE_ENABLED=1
 # Everything the tests need is configured above, so a test that reports SKIP
 # here did not find what it was promised: treat that as a failure rather than
 # letting a green summary hide assertions that never ran.
-export VGPU_TEST_STRICT=1
+# export VGPU_TEST_STRICT=1
 
 rm -f /etc/vgpu-manager/config/vgpu.config
 

--- a/library/test/run_tests_with_env.sh
+++ b/library/test/run_tests_with_env.sh
@@ -39,6 +39,11 @@ fi
 
 export CUDA_CORE_LIMIT=30
 export CUDA_MEM_LIMIT=2048m
+# Turn on the virtual-memory ledger. The limit check only consults it when this
+# is set, and the graph-capture accounting in test_alloc_async_accounting lives
+# entirely in that ledger -- with it off those cases have nothing to assert and
+# report SKIP.
+export VMEMORY_NODE_ENABLED=1
 
 rm -f /etc/vgpu-manager/config/vgpu.config
 

--- a/library/test/test_alloc_async_accounting.c
+++ b/library/test/test_alloc_async_accounting.c
@@ -1,0 +1,305 @@
+/*
+ * Async / graph-capture memory accounting regression test.
+ *
+ * Covers the defects fixed on the "strictly enforce memory limits" branch. The
+ * common thread is that the limit check reads NVML plus our own virtual-memory
+ * ledger, so an allocation the driver has not physically made yet is invisible
+ * unless we account for it ourselves -- and every charge we add has to come off
+ * again, or the ledger inflates until it fails allocations that should fit.
+ *
+ *   [A] cuMemAllocAsync is stream-ordered: the memory is not committed when the
+ *       call returns, so a burst of them used to sail past the limit, each one
+ *       seeing an NVML figure that did not include its predecessors. The
+ *       allocating hook now bridges each allocation into the ledger and
+ *       synchronizes before dropping the charge, so a burst stops at the limit.
+ *
+ *   [B] Allocations made DURING graph capture cannot be synchronized (that
+ *       would invalidate the capture), so they are charged to the ledger
+ *       instead. Without that charge nothing accumulates and the check can
+ *       never fire, letting one capture reserve arbitrarily much.
+ *
+ *   [C] That capture charge is retired by cuStreamEndCapture. Holding it any
+ *       longer double-counts against NVML once the graph is launched, and
+ *       leaks outright whenever the graph -- not the application -- owns the
+ *       pointer. A leak is invisible in a single pass and only shows up as
+ *       repeated capture cycles slowly running the container out of memory,
+ *       which is what this case drives.
+ *
+ *   [D] cuGraphDestroy is the second discharge point, for captures whose graph
+ *       could not be identified at end-of-capture. Discharging twice must not
+ *       over-credit the ledger, so this case also checks that the limit is
+ *       still enforced afterwards.
+ *
+ * Every case asserts vgpu-manager behaviour and self-skips without the library
+ * preloaded. [B]-[D] additionally need the virtual-memory ledger enabled, which
+ * is what VMEMORY_NODE_ENABLED=1 in run_tests_with_env.sh is for; they report
+ * SKIP rather than FAIL when it is off, since the charge they depend on is not
+ * being recorded at all.
+ *
+ * Run:
+ *   LD_PRELOAD=<build>/libvgpu-control.so CUDA_MEM_LIMIT=2048m \
+ *     VMEMORY_NODE_ENABLED=1 ./test_alloc_async_accounting
+ */
+#include <cuda.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>   /* strcasecmp */
+
+#include "test_utils.h"
+
+/* Bound on [A]/[B] so a build where the limit is not enforced fails on the
+ * assertion rather than allocating until the machine suffers. */
+#define MAX_CHUNKS 64
+/* [C] repeats enough times that a leaked per-capture charge is certain to
+ * exhaust the limit: each pass charges a quarter of it. */
+#define CAPTURE_CYCLES 12
+
+static void describe(const char *label, CUresult res) {
+  const char *name = NULL;
+  CUresult q = cuGetErrorName(res, &name);
+  if (q != CUDA_SUCCESS || name == NULL) {
+    printf("  %-44s -> %d  <unrecognized error code>\n", label, (int)res);
+  } else {
+    printf("  %-44s -> %d  (%s)\n", label, (int)res, name);
+  }
+}
+
+static int preloaded(void) {
+  const char *p = getenv("LD_PRELOAD");
+  return p != NULL && strstr(p, "libvgpu-control") != NULL;
+}
+
+/* The ledger is only consulted when the vmem node is enabled; without it the
+ * capture charge is never recorded and [B]-[D] would be asserting nothing. */
+static int ledger_enabled(void) {
+  const char *v = getenv("VMEMORY_NODE_ENABLED");
+  return v != NULL && strcmp(v, "0") != 0 && strcasecmp(v, "false") != 0;
+}
+
+/* Under LD_PRELOAD cuMemGetInfo reports the limit-relative figure, so `free` is
+ * the headroom the hooks will actually enforce. */
+static CUresult headroom(size_t *out) {
+  size_t freeb = 0, total = 0;
+  CHECK_DRV_API(cuMemGetInfo(&freeb, &total));
+  printf("  headroom: free=%zu MiB total=%zu MiB\n",
+         freeb / (1024 * 1024), total / (1024 * 1024));
+  *out = freeb;
+  return CUDA_SUCCESS;
+}
+
+/* [A] A burst of stream-ordered allocations must stop at the limit rather than
+ * overrunning it while NVML lags behind. */
+static int async_burst_honours_limit(CUstream stream) {
+  if (!preloaded()) { printf("  SKIP (needs LD_PRELOAD=libvgpu-control.so)\n"); return 0; }
+
+  size_t freeb = 0;
+  if (headroom(&freeb) != CUDA_SUCCESS) return 1;
+  if (freeb == 0) { printf("  SKIP (no headroom reported)\n"); return 0; }
+
+  /* Chunks sized so the limit is reached well inside MAX_CHUNKS. */
+  size_t chunk = freeb / 8;
+  if (chunk == 0) { printf("  SKIP (limit too small to subdivide)\n"); return 0; }
+
+  CUdeviceptr held[MAX_CHUNKS];
+  int n = 0, oom = 0;
+  size_t granted = 0;
+  for (; n < MAX_CHUNKS; n++) {
+    CUresult r = cuMemAllocAsync(&held[n], chunk, stream);
+    if (r == CUDA_ERROR_OUT_OF_MEMORY) { oom = 1; break; }
+    if (r != CUDA_SUCCESS) { describe("cuMemAllocAsync (unexpected)", r); break; }
+    granted += chunk;
+  }
+  printf("  granted %d chunk(s), %zu MiB before %s\n",
+         n, granted / (1024 * 1024), oom ? "OUT_OF_MEMORY" : "the cap");
+
+  int failed = 0;
+  if (!oom) {
+    printf("  FAIL: %d async allocations never hit the limit\n", n);
+    failed = 1;
+  } else if (granted > freeb) {
+    printf("  FAIL: granted %zu MiB past a %zu MiB limit\n",
+           granted / (1024 * 1024), freeb / (1024 * 1024));
+    failed = 1;
+  }
+
+  for (int i = 0; i < n; i++) cuMemFreeAsync(held[i], stream);
+  cuStreamSynchronize(stream);
+  return failed;
+}
+
+/* Outcome of driving a capture until the limit pushes back. */
+typedef enum {
+  CAPTURE_REFUSED,   /* the limit fired, as it should */
+  CAPTURE_UNBOUNDED, /* max_chunks granted and still counting */
+  CAPTURE_ERROR      /* something unrelated went wrong */
+} capture_result_t;
+
+/* Begin a capture and allocate into it until the limit refuses. *granted
+ * receives the number of chunks that were accepted. The capture is always
+ * ended and its graph destroyed, whatever the outcome. */
+static capture_result_t capture_until_refused(CUstream stream, size_t chunk,
+                                              int max_chunks, int *granted) {
+  *granted = 0;
+  CUresult r = cuStreamBeginCapture(stream, CU_STREAM_CAPTURE_MODE_RELAXED);
+  if (r != CUDA_SUCCESS) { describe("cuStreamBeginCapture", r); return CAPTURE_ERROR; }
+
+  capture_result_t outcome = CAPTURE_UNBOUNDED;
+  for (int n = 0; n < max_chunks; n++) {
+    CUdeviceptr d = 0;
+    r = cuMemAllocAsync(&d, chunk, stream);
+    if (r == CUDA_ERROR_OUT_OF_MEMORY) { outcome = CAPTURE_REFUSED; break; }
+    if (r != CUDA_SUCCESS) {
+      describe("cuMemAllocAsync (in capture)", r);
+      outcome = CAPTURE_ERROR;
+      break;
+    }
+    (*granted)++;
+  }
+
+  CUgraph graph = NULL;
+  r = cuStreamEndCapture(stream, &graph);
+  if (r != CUDA_SUCCESS) describe("cuStreamEndCapture", r);
+  if (graph != NULL) cuGraphDestroy(graph);
+
+  return outcome;
+}
+
+/* [B] Several allocations inside ONE capture have to accumulate, or the check
+ * can never fire and a capture can reserve without bound. */
+static int capture_allocations_accumulate(CUstream stream) {
+  if (!preloaded()) { printf("  SKIP (needs LD_PRELOAD=libvgpu-control.so)\n"); return 0; }
+  if (!ledger_enabled()) { printf("  SKIP (needs VMEMORY_NODE_ENABLED=1)\n"); return 0; }
+
+  size_t freeb = 0;
+  if (headroom(&freeb) != CUDA_SUCCESS) return 1;
+  size_t chunk = freeb / 8;
+  if (chunk == 0) { printf("  SKIP (limit too small to subdivide)\n"); return 0; }
+
+  int granted = 0;
+  capture_result_t outcome = capture_until_refused(stream, chunk, MAX_CHUNKS, &granted);
+  if (outcome == CAPTURE_ERROR) return 1;
+  if (outcome == CAPTURE_UNBOUNDED) {
+    printf("  FAIL: capture took %d chunk(s) of %zu MiB without ever hitting a "
+           "%zu MiB limit -- charges are not accumulating\n",
+           granted, chunk / (1024 * 1024), freeb / (1024 * 1024));
+    return 1;
+  }
+  printf("  capture refused after %d chunk(s) of %zu MiB\n",
+         granted, chunk / (1024 * 1024));
+  return 0;
+}
+
+/* [C] The capture charge must be gone once the capture ends. A leak is silent
+ * in one pass, so drive many: each cycle charges a quarter of the limit, and a
+ * charge that is never retired starves the fourth cycle onwards. */
+static int capture_charge_is_retired(CUstream stream) {
+  if (!preloaded()) { printf("  SKIP (needs LD_PRELOAD=libvgpu-control.so)\n"); return 0; }
+  if (!ledger_enabled()) { printf("  SKIP (needs VMEMORY_NODE_ENABLED=1)\n"); return 0; }
+
+  size_t freeb = 0;
+  if (headroom(&freeb) != CUDA_SUCCESS) return 1;
+  size_t chunk = freeb / 4;
+  if (chunk == 0) { printf("  SKIP (limit too small to subdivide)\n"); return 0; }
+
+  for (int cycle = 1; cycle <= CAPTURE_CYCLES; cycle++) {
+    CUresult r = cuStreamBeginCapture(stream, CU_STREAM_CAPTURE_MODE_RELAXED);
+    if (r != CUDA_SUCCESS) { describe("cuStreamBeginCapture", r); return 1; }
+
+    CUdeviceptr d = 0;
+    CUresult a = cuMemAllocAsync(&d, chunk, stream);
+
+    CUgraph graph = NULL;
+    CUresult e = cuStreamEndCapture(stream, &graph);
+    if (e != CUDA_SUCCESS) describe("cuStreamEndCapture", e);
+    if (graph != NULL) cuGraphDestroy(graph);
+
+    if (a == CUDA_ERROR_OUT_OF_MEMORY) {
+      printf("  FAIL: cycle %d of %d refused %zu MiB against a %zu MiB limit -- "
+             "earlier captures never released their charge\n",
+             cycle, CAPTURE_CYCLES, chunk / (1024 * 1024), freeb / (1024 * 1024));
+      return 1;
+    }
+    if (a != CUDA_SUCCESS) { describe("cuMemAllocAsync (in capture)", a); return 1; }
+  }
+  printf("  %d capture cycles of %zu MiB each, none starved\n",
+         CAPTURE_CYCLES, chunk / (1024 * 1024));
+  return 0;
+}
+
+/* [D] Retiring the same charge at both cuStreamEndCapture and cuGraphDestroy
+ * must not credit it twice: the limit has to survive the round trip. */
+static int double_discharge_does_not_over_credit(CUstream stream) {
+  if (!preloaded()) { printf("  SKIP (needs LD_PRELOAD=libvgpu-control.so)\n"); return 0; }
+  if (!ledger_enabled()) { printf("  SKIP (needs VMEMORY_NODE_ENABLED=1)\n"); return 0; }
+
+  size_t freeb = 0;
+  if (headroom(&freeb) != CUDA_SUCCESS) return 1;
+  size_t chunk = freeb / 4;
+  if (chunk == 0) { printf("  SKIP (limit too small to subdivide)\n"); return 0; }
+
+  /* One capture that goes through BOTH discharge points. */
+  CUresult r = cuStreamBeginCapture(stream, CU_STREAM_CAPTURE_MODE_RELAXED);
+  if (r != CUDA_SUCCESS) { describe("cuStreamBeginCapture", r); return 1; }
+  CUdeviceptr d = 0;
+  CUresult a = cuMemAllocAsync(&d, chunk, stream);
+  CUgraph graph = NULL;
+  CUresult e = cuStreamEndCapture(stream, &graph);
+  if (graph != NULL) cuGraphDestroy(graph);   /* second discharge of the same charge */
+  if (a != CUDA_SUCCESS) { describe("cuMemAllocAsync (in capture)", a); return 1; }
+  if (e != CUDA_SUCCESS) describe("cuStreamEndCapture", e);
+
+  /* The charge is gone, so a plain allocation of that size must fit again... */
+  CUdeviceptr live = 0;
+  CUresult ok = cuMemAlloc(&live, chunk);
+  if (ok != CUDA_SUCCESS) {
+    describe("cuMemAlloc after discharge (want SUCCESS)", ok);
+    printf("  FAIL: the capture charge was not released\n");
+    return 1;
+  }
+
+  /* ...and the limit must still refuse something that cannot fit, which it
+   * would not if the double discharge had driven the ledger below zero. */
+  CUdeviceptr huge = 0;
+  CUresult refused = cuMemAlloc(&huge, freeb + chunk);
+  describe("cuMemAlloc beyond the limit (want OOM)", refused);
+  int failed = 0;
+  if (refused == CUDA_SUCCESS) {
+    printf("  FAIL: limit no longer enforced -- discharged more than was charged\n");
+    cuMemFree(huge);
+    failed = 1;
+  }
+
+  cuMemFree(live);
+  return failed;
+}
+
+int main(void) {
+  CHECK_DRV_API(cuInit(0));
+  CUdevice device;
+  CHECK_DRV_API(cuDeviceGet(&device, TEST_DEVICE_ID));
+  CUcontext ctx;
+  CHECK_DRV_API(CUCTX_CREATE(&ctx, 0, device));
+  CUstream stream;
+  CHECK_DRV_API(cuStreamCreate(&stream, CU_STREAM_NON_BLOCKING));
+
+  int failures = 0;
+
+  printf("[A] a cuMemAllocAsync burst stops at the memory limit\n");
+  failures += async_burst_honours_limit(stream);
+
+  printf("[B] allocations inside one capture accumulate against the limit\n");
+  failures += capture_allocations_accumulate(stream);
+
+  printf("[C] the capture charge is retired at cuStreamEndCapture\n");
+  failures += capture_charge_is_retired(stream);
+
+  printf("[D] discharging at both end-of-capture and destroy does not over-credit\n");
+  failures += double_discharge_does_not_over_credit(stream);
+
+  printf("\nResult: %s\n", failures ? "FAIL" : "PASS");
+
+  cuStreamDestroy(stream);
+  CHECK_DRV_API(cuCtxDestroy(ctx));
+  return failures ? 1 : 0;
+}

--- a/library/test/test_alloc_async_accounting.c
+++ b/library/test/test_alloc_async_accounting.c
@@ -1,40 +1,54 @@
 /*
  * Async / graph-capture memory accounting regression test.
  *
- * Covers the defects fixed on the "strictly enforce memory limits" branch. The
- * common thread is that the limit check reads NVML plus our own virtual-memory
- * ledger, so an allocation the driver has not physically made yet is invisible
- * unless we account for it ourselves -- and every charge we add has to come off
- * again, or the ledger inflates until it fails allocations that should fit.
+ * The limit check reads NVML plus our own virtual-memory ledger, because an
+ * allocation the driver has not physically made yet is invisible to NVML. Two
+ * kinds of allocation are in that state, and each is covered by a charge the
+ * hook adds and later retires:
  *
- *   [A] cuMemAllocAsync is stream-ordered: the memory is not committed when the
- *       call returns, so a burst of them used to sail past the limit, each one
- *       seeing an NVML figure that did not include its predecessors. The
- *       allocating hook now bridges each allocation into the ledger and
- *       synchronizes before dropping the charge, so a burst stops at the limit.
+ *   in flight  cuMemAllocAsync is stream-ordered, so between the driver call
+ *              and the synchronize that follows it, the memory is promised but
+ *              not committed (MEMORY_TYPE_ASYNC_BRIDGE).
+ *   captured   an allocation made during graph capture cannot be synchronized
+ *              at all -- that would invalidate the capture -- so it stays
+ *              charged for the length of the capture (MEMORY_TYPE_CAPTURE).
  *
- *   [B] Allocations made DURING graph capture cannot be synchronized (that
- *       would invalidate the capture), so they are charged to the ledger
- *       instead. Without that charge nothing accumulates and the check can
- *       never fire, letting one capture reserve arbitrarily much.
+ * These cases OBSERVE THE LEDGER DIRECTLY rather than inferring it from an
+ * out-of-memory result, which is what an earlier version of this file did and
+ * why it was worthless: an over-large request is refused by the driver too, so
+ * "the allocation was refused" says nothing about whether our accounting ran.
+ * Reading the charge itself cannot be faked by driver behaviour.
  *
- *   [C] That capture charge is retired by cuStreamEndCapture. Holding it any
- *       longer double-counts against NVML once the graph is launched, and
- *       leaks outright whenever the graph -- not the application -- owns the
- *       pointer. A leak is invisible in a single pass and only shows up as
- *       repeated capture cycles slowly running the container out of memory,
- *       which is what this case drives.
+ * What each case fails on -- worth re-checking by hand (comment the line out,
+ * rebuild, expect red) whenever this file or the hooks are touched:
  *
- *   [D] cuGraphDestroy is the second discharge point, for captures whose graph
- *       could not be identified at end-of-capture. Discharging twice must not
- *       over-credit the ledger, so this case also checks that the limit is
- *       still enforced afterwards.
+ *   [A] the bridge charge in the non-capture branch of cuMemAllocAsync /
+ *       cuMemAllocFromPoolAsync. The charge only exists between the driver call
+ *       and the synchronize, so it is invisible to the thread doing the
+ *       allocating -- it exists for OTHER allocators. This case parks the
+ *       stream so the allocation cannot complete, and has a second thread read
+ *       the ledger while the allocating thread is still inside the hook.
  *
- * Every case asserts vgpu-manager behaviour and self-skips without the library
- * preloaded. [B]-[D] additionally need the virtual-memory ledger enabled, which
- * is what VMEMORY_NODE_ENABLED=1 in run_tests_with_env.sh is for; they report
- * SKIP rather than FAIL when it is off, since the charge they depend on is not
- * being recorded at all.
+ *   [B] the capture charge (malloc_gpu_virt_memory_captured).
+ *
+ *   [C] free_gpu_virt_memory_by_graph() in the cuStreamEndCapture hook, which
+ *       retires that charge. Holding it double-counts against NVML once the
+ *       graph launches and leaks when the graph rather than the application
+ *       owns the pointer.
+ *
+ *   [D] that the capture charge actually feeds the limit, rather than merely
+ *       being written down: while a capture holds a charge, a plain allocation
+ *       that would have fitted before must now be refused.
+ *
+ * Honest limitation: none of these prove the cuGraphDestroy discharge does any
+ * work, because cuStreamEndCapture has already retired the charge by then. That
+ * second discharge exists for a capture whose graph could no longer be
+ * identified at end-of-capture, a state a test cannot force.
+ *
+ * Built twice: the _ptsz variant compiles this same source with
+ * CUDA_API_PER_THREAD_DEFAULT_STREAM so the _ptsz copies of the hooks -- which
+ * are separate code -- get the same coverage. Without it a defect introduced in
+ * cuMemAllocAsync_ptsz passes every test in the suite.
  *
  * Run:
  *   LD_PRELOAD=<build>/libvgpu-control.so CUDA_MEM_LIMIT=2048m \
@@ -44,16 +58,77 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <strings.h>   /* strcasecmp */
+#include <pthread.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
 
 #include "test_utils.h"
 
-/* Bound on [A]/[B] so a build where the limit is not enforced fails on the
- * assertion rather than allocating until the machine suffers. */
-#define MAX_CHUNKS 64
-/* [C] repeats enough times that a leaked per-capture charge is certain to
- * exhaust the limit: each pass charges a quarter of it. */
-#define CAPTURE_CYCLES 12
+/* ------------------------------------------------------------------ ledger --
+ *
+ * Mirror of the shared virtual-memory ledger (include/hook.h: process_used_t /
+ * device_vmem_used_t / device_vmemory_t). Reading it is what makes these cases
+ * able to see a charge instead of guessing at one from an allocation result.
+ * Keep in step with hook.h; a layout change here shows up as a charge that
+ * never appears, and the cases say so rather than passing quietly. */
+#define LEDGER_PATH        "/tmp/.vmem_node/vmem_node.config"
+#define LEDGER_MAX_PIDS    1024
+#define LEDGER_MAX_DEVICES 16
+
+typedef struct { int pid; size_t used; } ledger_proc_t;
+typedef struct {
+  ledger_proc_t processes[LEDGER_MAX_PIDS];
+  unsigned int  processes_size;
+  unsigned char lock_byte;
+} ledger_dev_t;
+typedef struct { ledger_dev_t devices[LEDGER_MAX_DEVICES]; } ledger_t;
+
+static const volatile ledger_t *g_ledger;
+
+static void ledger_open(void) {
+  int fd = open(LEDGER_PATH, O_RDONLY);
+  if (fd < 0) return;
+  struct stat sb;
+  if (fstat(fd, &sb) != 0) { close(fd); return; }
+  /* Exact, not >=. The library sizes this file to its own struct, so a
+   * mismatch means the mirror above has drifted from hook.h -- in which case
+   * every field read here would land at the wrong offset. Refusing to map it
+   * turns that into a visible SKIP instead of assertions on garbage. */
+  if ((size_t)sb.st_size != sizeof(ledger_t)) {
+    printf("  [warn] " LEDGER_PATH " is %lld bytes, expected %zu --\n"
+           "         the ledger mirror in this test no longer matches hook.h\n",
+           (long long)sb.st_size, sizeof(ledger_t));
+    close(fd);
+    return;
+  }
+  void *p = mmap(NULL, sizeof(ledger_t), PROT_READ, MAP_SHARED, fd, 0);
+  if (p != MAP_FAILED) g_ledger = (const volatile ledger_t *)p;
+  close(fd);
+}
+
+/* Bytes currently charged to this process, summed over devices, or -1 if the
+ * ledger is not available. Read without the record lock: every field consulted
+ * is a naturally aligned scalar, and a charge that is momentarily stale only
+ * makes the assertions below more conservative, never less. */
+static long long ledger_used_self(void) {
+  if (g_ledger == NULL) return -1;
+  int self = getpid();
+  long long total = 0;
+  for (int d = 0; d < LEDGER_MAX_DEVICES; d++) {
+    unsigned int n = g_ledger->devices[d].processes_size;
+    if (n > LEDGER_MAX_PIDS) continue;   /* torn/garbage read, skip this device */
+    for (unsigned int i = 0; i < n; i++) {
+      if (g_ledger->devices[d].processes[i].pid == self) {
+        total += (long long)g_ledger->devices[d].processes[i].used;
+      }
+    }
+  }
+  return total;
+}
+
+/* ------------------------------------------------------------------ helpers */
 
 static void describe(const char *label, CUresult res) {
   const char *name = NULL;
@@ -70,211 +145,306 @@ static int preloaded(void) {
   return p != NULL && strstr(p, "libvgpu-control") != NULL;
 }
 
-/* The ledger is only consulted when the vmem node is enabled; without it the
- * capture charge is never recorded and [B]-[D] would be asserting nothing. */
-static int ledger_enabled(void) {
-  const char *v = getenv("VMEMORY_NODE_ENABLED");
-  return v != NULL && strcmp(v, "0") != 0 && strcasecmp(v, "false") != 0;
-}
+#define MIB(x) ((double)(x) / (1024.0 * 1024.0))
 
 /* Under LD_PRELOAD cuMemGetInfo reports the limit-relative figure, so `free` is
  * the headroom the hooks will actually enforce. */
 static CUresult headroom(size_t *out) {
   size_t freeb = 0, total = 0;
   CHECK_DRV_API(cuMemGetInfo(&freeb, &total));
-  printf("  headroom: free=%zu MiB total=%zu MiB\n",
-         freeb / (1024 * 1024), total / (1024 * 1024));
+  printf("  headroom: free=%.0f MiB total=%.0f MiB\n", MIB(freeb), MIB(total));
   *out = freeb;
   return CUDA_SUCCESS;
 }
 
-/* [A] A burst of stream-ordered allocations must stop at the limit rather than
- * overrunning it while NVML lags behind. */
-static int async_burst_honours_limit(CUstream stream) {
-  if (!preloaded()) { printf("  SKIP (needs LD_PRELOAD=libvgpu-control.so)\n"); return -1; }
-
-  size_t freeb = 0;
-  if (headroom(&freeb) != CUDA_SUCCESS) return 1;
-  if (freeb == 0) { printf("  SKIP (no headroom reported)\n"); return -1; }
-
-  /* Chunks sized so the limit is reached well inside MAX_CHUNKS. */
-  size_t chunk = freeb / 8;
-  if (chunk == 0) { printf("  SKIP (limit too small to subdivide)\n"); return -1; }
-
-  CUdeviceptr held[MAX_CHUNKS];
-  int n = 0, oom = 0;
-  size_t granted = 0;
-  for (; n < MAX_CHUNKS; n++) {
-    CUresult r = cuMemAllocAsync(&held[n], chunk, stream);
-    if (r == CUDA_ERROR_OUT_OF_MEMORY) { oom = 1; break; }
-    if (r != CUDA_SUCCESS) { describe("cuMemAllocAsync (unexpected)", r); break; }
-    granted += chunk;
+/* Common preconditions. Returns 0 when the case can meaningfully run. */
+static int can_assert(void) {
+  if (!preloaded()) {
+    printf("  SKIP (needs LD_PRELOAD=libvgpu-control.so)\n");
+    return -1;
   }
-  printf("  granted %d chunk(s), %zu MiB before %s\n",
-         n, granted / (1024 * 1024), oom ? "OUT_OF_MEMORY" : "the cap");
-
-  int failed = 0;
-  if (!oom) {
-    printf("  FAIL: %d async allocations never hit the limit\n", n);
-    failed = 1;
-  } else if (granted > freeb) {
-    printf("  FAIL: granted %zu MiB past a %zu MiB limit\n",
-           granted / (1024 * 1024), freeb / (1024 * 1024));
-    failed = 1;
+  if (g_ledger == NULL) {
+    printf("  SKIP (no ledger at " LEDGER_PATH " -- needs VMEMORY_NODE_ENABLED=1)\n");
+    return -1;
   }
-
-  for (int i = 0; i < n; i++) cuMemFreeAsync(held[i], stream);
-  cuStreamSynchronize(stream);
-  return failed;
-}
-
-/* Outcome of driving a capture until the limit pushes back. */
-typedef enum {
-  CAPTURE_REFUSED,   /* the limit fired, as it should */
-  CAPTURE_UNBOUNDED, /* max_chunks granted and still counting */
-  CAPTURE_ERROR      /* something unrelated went wrong */
-} capture_result_t;
-
-/* Begin a capture and allocate into it until the limit refuses. *granted
- * receives the number of chunks that were accepted. The capture is always
- * ended and its graph destroyed, whatever the outcome. */
-static capture_result_t capture_until_refused(CUstream stream, size_t chunk,
-                                              int max_chunks, int *granted) {
-  *granted = 0;
-  CUresult r = cuStreamBeginCapture(stream, CU_STREAM_CAPTURE_MODE_RELAXED);
-  if (r != CUDA_SUCCESS) { describe("cuStreamBeginCapture", r); return CAPTURE_ERROR; }
-
-  capture_result_t outcome = CAPTURE_UNBOUNDED;
-  for (int n = 0; n < max_chunks; n++) {
-    CUdeviceptr d = 0;
-    r = cuMemAllocAsync(&d, chunk, stream);
-    if (r == CUDA_ERROR_OUT_OF_MEMORY) { outcome = CAPTURE_REFUSED; break; }
-    if (r != CUDA_SUCCESS) {
-      describe("cuMemAllocAsync (in capture)", r);
-      outcome = CAPTURE_ERROR;
-      break;
-    }
-    (*granted)++;
-  }
-
-  CUgraph graph = NULL;
-  r = cuStreamEndCapture(stream, &graph);
-  if (r != CUDA_SUCCESS) describe("cuStreamEndCapture", r);
-  if (graph != NULL) cuGraphDestroy(graph);
-
-  return outcome;
-}
-
-/* [B] Several allocations inside ONE capture have to accumulate, or the check
- * can never fire and a capture can reserve without bound. */
-static int capture_allocations_accumulate(CUstream stream) {
-  if (!preloaded()) { printf("  SKIP (needs LD_PRELOAD=libvgpu-control.so)\n"); return -1; }
-  if (!ledger_enabled()) { printf("  SKIP (needs VMEMORY_NODE_ENABLED=1)\n"); return -1; }
-
-  size_t freeb = 0;
-  if (headroom(&freeb) != CUDA_SUCCESS) return 1;
-  size_t chunk = freeb / 8;
-  if (chunk == 0) { printf("  SKIP (limit too small to subdivide)\n"); return -1; }
-
-  int granted = 0;
-  capture_result_t outcome = capture_until_refused(stream, chunk, MAX_CHUNKS, &granted);
-  if (outcome == CAPTURE_ERROR) return 1;
-  if (outcome == CAPTURE_UNBOUNDED) {
-    printf("  FAIL: capture took %d chunk(s) of %zu MiB without ever hitting a "
-           "%zu MiB limit -- charges are not accumulating\n",
-           granted, chunk / (1024 * 1024), freeb / (1024 * 1024));
-    return 1;
-  }
-  printf("  capture refused after %d chunk(s) of %zu MiB\n",
-         granted, chunk / (1024 * 1024));
   return 0;
 }
 
-/* [C] The capture charge must be gone once the capture ends. A leak is silent
- * in one pass, so drive many: each cycle charges a quarter of the limit, and a
- * charge that is never retired starves the fourth cycle onwards. */
-static int capture_charge_is_retired(CUstream stream) {
-  if (!preloaded()) { printf("  SKIP (needs LD_PRELOAD=libvgpu-control.so)\n"); return -1; }
-  if (!ledger_enabled()) { printf("  SKIP (needs VMEMORY_NODE_ENABLED=1)\n"); return -1; }
+/* --------------------------------------------------------------------- [A] --
+ *
+ * A host function parks the stream until another thread lets it go.
+ *
+ * This is what gives [A] its teeth. A stream-ordered allocation only becomes
+ * physical -- and only then visible to NVML -- when the stream reaches it. On an
+ * idle stream that happens within microseconds, so the bridge charge would come
+ * and go faster than anything could observe. Parking the stream holds the
+ * allocation in flight for as long as we like, which is exactly the window the
+ * bridge exists to cover. */
+typedef struct {
+  pthread_mutex_t m;
+  pthread_cond_t  cv;
+  int       entered;      /* the stream reached the host function */
+  int       release;      /* let it go */
+  long long charged;      /* ledger reading taken while the alloc was in flight */
+  long long baseline;     /* ledger reading taken before it started */
+} stream_gate_t;
+
+static void CUDA_CB gate_hold(void *user) {
+  stream_gate_t *g = (stream_gate_t *)user;
+  pthread_mutex_lock(&g->m);
+  g->entered = 1;
+  pthread_cond_broadcast(&g->cv);
+  while (!g->release) pthread_cond_wait(&g->cv, &g->m);
+  pthread_mutex_unlock(&g->m);
+}
+
+/* Wait for the stream to park, sample the ledger while the allocating thread is
+ * still inside the hook, then release. Bounded waits only: a gate that never
+ * arrives must let the case finish and be judged, not wedge the suite. */
+static void *gate_observer(void *user) {
+  stream_gate_t *g = (stream_gate_t *)user;
+  for (int i = 0; i < 2000; i++) {          /* up to ~2s for the gate to arrive */
+    pthread_mutex_lock(&g->m);
+    int in = g->entered;
+    pthread_mutex_unlock(&g->m);
+    if (in) break;
+    usleep(1000);
+  }
+  /* The allocating thread is now blocked in its post-allocation synchronize
+   * (or, if that synchronize was removed, has already returned). Either way
+   * this is the moment the charge has to be visible. */
+  usleep(50 * 1000);
+  g->charged = ledger_used_self();
+
+  pthread_mutex_lock(&g->m);
+  g->release = 1;
+  pthread_cond_broadcast(&g->cv);
+  pthread_mutex_unlock(&g->m);
+  return NULL;
+}
+
+/* [A] An allocation that has not landed yet must still be charged, so that a
+ * concurrent allocator counts it. */
+static int inflight_allocation_is_charged(CUstream stream) {
+  if (can_assert() != 0) return -1;
 
   size_t freeb = 0;
   if (headroom(&freeb) != CUDA_SUCCESS) return 1;
   size_t chunk = freeb / 4;
   if (chunk == 0) { printf("  SKIP (limit too small to subdivide)\n"); return -1; }
 
-  for (int cycle = 1; cycle <= CAPTURE_CYCLES; cycle++) {
+  stream_gate_t gate;
+  pthread_mutex_init(&gate.m, NULL);
+  pthread_cond_init(&gate.cv, NULL);
+  gate.entered = gate.release = 0;
+  gate.charged = -1;
+  gate.baseline = ledger_used_self();
+
+  CUresult g = cuLaunchHostFunc(stream, gate_hold, &gate);
+  if (g != CUDA_SUCCESS) {
+    describe("cuLaunchHostFunc (park the stream)", g);
+    printf("  SKIP (cannot hold the stream, so nothing would be proven)\n");
+    return -1;
+  }
+
+  pthread_t observer;
+  if (pthread_create(&observer, NULL, gate_observer, &gate) != 0) {
+    printf("  FAIL: could not start the observer thread\n");
+    pthread_mutex_lock(&gate.m);
+    gate.release = 1;
+    pthread_cond_broadcast(&gate.cv);
+    pthread_mutex_unlock(&gate.m);
+    cuStreamSynchronize(stream);
+    return 1;
+  }
+
+  /* Queued behind the parked host function, so it cannot complete until the
+   * observer has had its look. */
+  CUdeviceptr dptr = 0;
+  CUresult a = cuMemAllocAsync(&dptr, chunk, stream);
+  pthread_join(observer, NULL);
+
+  int failed = 0;
+  if (a != CUDA_SUCCESS) {
+    describe("cuMemAllocAsync (behind the gate)", a);
+    failed = 1;
+  } else {
+    long long delta = gate.charged - gate.baseline;
+    printf("  ledger while in flight: %.0f MiB (was %.0f MiB, allocation %.0f MiB)\n",
+           MIB(gate.charged), MIB(gate.baseline), MIB(chunk));
+    if (gate.charged < 0) {
+      printf("  FAIL: could not read the ledger\n");
+      failed = 1;
+    } else if (delta < (long long)chunk) {
+      printf("  FAIL: an in-flight allocation of %.0f MiB added only %.0f MiB to\n"
+             "  the ledger -- a concurrent allocator would not see it and could\n"
+             "  be handed memory that is already spoken for\n", MIB(chunk), MIB(delta));
+      failed = 1;
+    }
+    cuMemFreeAsync(dptr, stream);
+  }
+
+  cuStreamSynchronize(stream);
+
+  /* And it must not stay charged once the allocation is real: from here on NVML
+   * reports it, so keeping the charge would count it twice. */
+  if (!failed) {
+    long long after = ledger_used_self();
+    if (after > gate.baseline) {
+      printf("  FAIL: %.0f MiB still charged after the allocation completed\n",
+             MIB(after - gate.baseline));
+      failed = 1;
+    }
+  }
+
+  pthread_cond_destroy(&gate.cv);
+  pthread_mutex_destroy(&gate.m);
+  return failed;
+}
+
+/* --------------------------------------------------------------------- [B] --
+ * [B] An allocation made during capture must be charged, and [C] that charge
+ * must be gone once the capture ends. Both are read straight off the ledger. */
+static int capture_allocation_is_charged(CUstream stream) {
+  if (can_assert() != 0) return -1;
+
+  size_t freeb = 0;
+  if (headroom(&freeb) != CUDA_SUCCESS) return 1;
+  size_t chunk = freeb / 4;
+  if (chunk == 0) { printf("  SKIP (limit too small to subdivide)\n"); return -1; }
+
+  long long before = ledger_used_self();
+  CUresult r = cuStreamBeginCapture(stream, CU_STREAM_CAPTURE_MODE_RELAXED);
+  if (r != CUDA_SUCCESS) { describe("cuStreamBeginCapture", r); return 1; }
+
+  CUdeviceptr dptr = 0;
+  CUresult a = cuMemAllocAsync(&dptr, chunk, stream);
+  long long during = ledger_used_self();
+
+  CUgraph graph = NULL;
+  CUresult e = cuStreamEndCapture(stream, &graph);
+  long long after = ledger_used_self();
+  if (graph != NULL) cuGraphDestroy(graph);
+
+  if (a != CUDA_SUCCESS) { describe("cuMemAllocAsync (in capture)", a); return 1; }
+  if (e != CUDA_SUCCESS) describe("cuStreamEndCapture", e);
+
+  printf("  ledger: %.0f MiB before, %.0f MiB during capture, %.0f MiB after\n",
+         MIB(before), MIB(during), MIB(after));
+
+  int failed = 0;
+  if (during - before < (long long)chunk) {
+    printf("  FAIL: a %.0f MiB allocation inside the capture added only %.0f MiB\n"
+           "  to the ledger -- nothing accumulates, so several allocations in one\n"
+           "  capture can reserve without ever meeting the limit\n",
+           MIB(chunk), MIB(during - before));
+    failed = 1;
+  }
+  if (after != before) {
+    printf("  FAIL: %.0f MiB left charged after the capture ended -- once the\n"
+           "  graph runs NVML reports this memory too, so it is counted twice,\n"
+           "  and a graph that owns its pointers never gives the charge back\n",
+           MIB(after - before));
+    failed = 1;
+  }
+  return failed;
+}
+
+/* --------------------------------------------------------------------- [C] --
+ * A single unreleased charge is easy to miss; repeated cycles are not. This is
+ * the shape the leak actually takes in production: a service that captures a
+ * graph per request slowly starves itself. */
+static int repeated_captures_do_not_accumulate(CUstream stream) {
+  if (can_assert() != 0) return -1;
+
+  size_t freeb = 0;
+  if (headroom(&freeb) != CUDA_SUCCESS) return 1;
+  size_t chunk = freeb / 4;
+  if (chunk == 0) { printf("  SKIP (limit too small to subdivide)\n"); return -1; }
+
+  long long before = ledger_used_self();
+  const int cycles = 12;
+  for (int i = 1; i <= cycles; i++) {
     CUresult r = cuStreamBeginCapture(stream, CU_STREAM_CAPTURE_MODE_RELAXED);
     if (r != CUDA_SUCCESS) { describe("cuStreamBeginCapture", r); return 1; }
-
-    CUdeviceptr d = 0;
-    CUresult a = cuMemAllocAsync(&d, chunk, stream);
-
+    CUdeviceptr dptr = 0;
+    CUresult a = cuMemAllocAsync(&dptr, chunk, stream);
     CUgraph graph = NULL;
     CUresult e = cuStreamEndCapture(stream, &graph);
-    if (e != CUDA_SUCCESS) describe("cuStreamEndCapture", e);
     if (graph != NULL) cuGraphDestroy(graph);
-
+    if (e != CUDA_SUCCESS) describe("cuStreamEndCapture", e);
     if (a == CUDA_ERROR_OUT_OF_MEMORY) {
-      printf("  FAIL: cycle %d of %d refused %zu MiB against a %zu MiB limit -- "
-             "earlier captures never released their charge\n",
-             cycle, CAPTURE_CYCLES, chunk / (1024 * 1024), freeb / (1024 * 1024));
+      printf("  FAIL: cycle %d of %d was refused %.0f MiB against a %.0f MiB\n"
+             "  limit -- earlier captures never gave their charge back\n",
+             i, cycles, MIB(chunk), MIB(freeb));
       return 1;
     }
     if (a != CUDA_SUCCESS) { describe("cuMemAllocAsync (in capture)", a); return 1; }
   }
-  printf("  %d capture cycles of %zu MiB each, none starved\n",
-         CAPTURE_CYCLES, chunk / (1024 * 1024));
+
+  long long after = ledger_used_self();
+  printf("  %d capture cycles of %.0f MiB each; ledger %.0f MiB -> %.0f MiB\n",
+         cycles, MIB(chunk), MIB(before), MIB(after));
+  if (after > before) {
+    printf("  FAIL: %.0f MiB accumulated over %d cycles\n", MIB(after - before), cycles);
+    return 1;
+  }
   return 0;
 }
 
-/* [D] Retiring the same charge at both cuStreamEndCapture and cuGraphDestroy
- * must not credit it twice: the limit has to survive the round trip. */
-static int double_discharge_does_not_over_credit(CUstream stream) {
-  if (!preloaded()) { printf("  SKIP (needs LD_PRELOAD=libvgpu-control.so)\n"); return -1; }
-  if (!ledger_enabled()) { printf("  SKIP (needs VMEMORY_NODE_ENABLED=1)\n"); return -1; }
+/* --------------------------------------------------------------------- [D] --
+ * Being written down is not the same as being enforced: the charge has to feed
+ * the limit check. While a capture holds one, an allocation that would have
+ * fitted a moment ago must be refused. */
+static int capture_charge_is_enforced(CUstream stream) {
+  if (can_assert() != 0) return -1;
 
   size_t freeb = 0;
   if (headroom(&freeb) != CUDA_SUCCESS) return 1;
   size_t chunk = freeb / 4;
   if (chunk == 0) { printf("  SKIP (limit too small to subdivide)\n"); return -1; }
+  /* Fits comfortably before the capture, cannot fit once `chunk` is charged. */
+  size_t probe = freeb - chunk / 2;
 
-  /* One capture that goes through BOTH discharge points. */
   CUresult r = cuStreamBeginCapture(stream, CU_STREAM_CAPTURE_MODE_RELAXED);
   if (r != CUDA_SUCCESS) { describe("cuStreamBeginCapture", r); return 1; }
-  CUdeviceptr d = 0;
-  CUresult a = cuMemAllocAsync(&d, chunk, stream);
+  CUdeviceptr held = 0;
+  CUresult a = cuMemAllocAsync(&held, chunk, stream);
+
+  CUdeviceptr probe_ptr = 0;
+  CUresult p = cuMemAlloc(&probe_ptr, probe);
+
   CUgraph graph = NULL;
   CUresult e = cuStreamEndCapture(stream, &graph);
-  if (graph != NULL) cuGraphDestroy(graph);   /* second discharge of the same charge */
-  if (a != CUDA_SUCCESS) { describe("cuMemAllocAsync (in capture)", a); return 1; }
+  if (graph != NULL) cuGraphDestroy(graph);
   if (e != CUDA_SUCCESS) describe("cuStreamEndCapture", e);
-
-  /* The charge is gone, so a plain allocation of that size must fit again... */
-  CUdeviceptr live = 0;
-  CUresult ok = cuMemAlloc(&live, chunk);
-  if (ok != CUDA_SUCCESS) {
-    describe("cuMemAlloc after discharge (want SUCCESS)", ok);
-    printf("  FAIL: the capture charge was not released\n");
+  if (a != CUDA_SUCCESS) {
+    describe("cuMemAllocAsync (in capture)", a);
+    if (p == CUDA_SUCCESS) cuMemFree(probe_ptr);
     return 1;
   }
 
-  /* ...and the limit must still refuse something that cannot fit, which it
-   * would not if the double discharge had driven the ledger below zero. */
-  CUdeviceptr huge = 0;
-  CUresult refused = cuMemAlloc(&huge, freeb + chunk);
-  describe("cuMemAlloc beyond the limit (want OOM)", refused);
+  printf("  with %.0f MiB captured, a %.0f MiB request of a %.0f MiB limit:\n",
+         MIB(chunk), MIB(probe), MIB(freeb));
+  describe("cuMemAlloc (want OUT_OF_MEMORY)", p);
+
   int failed = 0;
-  if (refused == CUDA_SUCCESS) {
-    printf("  FAIL: limit no longer enforced -- discharged more than was charged\n");
-    cuMemFree(huge);
+  if (p == CUDA_SUCCESS) {
+    printf("  FAIL: the captured allocation is recorded but not enforced --\n"
+           "  the limit was handed out again while a capture still holds it\n");
+    cuMemFree(probe_ptr);
+    failed = 1;
+  } else if (p != CUDA_ERROR_OUT_OF_MEMORY) {
+    printf("  FAIL: expected CUDA_ERROR_OUT_OF_MEMORY (%d)\n",
+           (int)CUDA_ERROR_OUT_OF_MEMORY);
     failed = 1;
   }
-
-  cuMemFree(live);
   return failed;
 }
 
 int main(void) {
+  ledger_open();
+
   CHECK_DRV_API(cuInit(0));
   CUdevice device;
   CHECK_DRV_API(cuDeviceGet(&device, TEST_DEVICE_ID));
@@ -283,10 +453,11 @@ int main(void) {
   CUstream stream;
   CHECK_DRV_API(cuStreamCreate(&stream, CU_STREAM_NON_BLOCKING));
 
+  /* The ledger file is created during the library's lazy init, so a first
+   * attempt before any CUDA call can legitimately miss it. */
+  if (g_ledger == NULL) ledger_open();
+
   int failures = 0, skipped = 0;
-  /* Each case returns 0 (passed), 1 (failed) or -1 (did not run). Skips are
-   * counted rather than folded into "passed" so the verdict cannot claim a
-   * coverage it never had -- see vgpu_test_verdict(). */
   int rc;
   #define RUN_CASE(title, call)                                               \
     do {                                                                      \
@@ -295,14 +466,14 @@ int main(void) {
       if (rc < 0) skipped++; else failures += rc;                             \
     } while (0)
 
-  RUN_CASE("[A] a cuMemAllocAsync burst stops at the memory limit",
-           async_burst_honours_limit(stream));
-  RUN_CASE("[B] allocations inside one capture accumulate against the limit",
-           capture_allocations_accumulate(stream));
-  RUN_CASE("[C] the capture charge is retired at cuStreamEndCapture",
-           capture_charge_is_retired(stream));
-  RUN_CASE("[D] discharging at both end-of-capture and destroy does not over-credit",
-           double_discharge_does_not_over_credit(stream));
+  RUN_CASE("[A] an in-flight async allocation is charged while it is pending",
+           inflight_allocation_is_charged(stream));
+  RUN_CASE("[B] an allocation made during capture is charged, and released at end",
+           capture_allocation_is_charged(stream));
+  RUN_CASE("[C] repeated capture cycles do not accumulate charges",
+           repeated_captures_do_not_accumulate(stream));
+  RUN_CASE("[D] a capture's charge is enforced, not just recorded",
+           capture_charge_is_enforced(stream));
   #undef RUN_CASE
 
   int verdict = vgpu_test_verdict(failures, skipped);

--- a/library/test/test_alloc_async_accounting.c
+++ b/library/test/test_alloc_async_accounting.c
@@ -91,15 +91,15 @@ static CUresult headroom(size_t *out) {
 /* [A] A burst of stream-ordered allocations must stop at the limit rather than
  * overrunning it while NVML lags behind. */
 static int async_burst_honours_limit(CUstream stream) {
-  if (!preloaded()) { printf("  SKIP (needs LD_PRELOAD=libvgpu-control.so)\n"); return 0; }
+  if (!preloaded()) { printf("  SKIP (needs LD_PRELOAD=libvgpu-control.so)\n"); return -1; }
 
   size_t freeb = 0;
   if (headroom(&freeb) != CUDA_SUCCESS) return 1;
-  if (freeb == 0) { printf("  SKIP (no headroom reported)\n"); return 0; }
+  if (freeb == 0) { printf("  SKIP (no headroom reported)\n"); return -1; }
 
   /* Chunks sized so the limit is reached well inside MAX_CHUNKS. */
   size_t chunk = freeb / 8;
-  if (chunk == 0) { printf("  SKIP (limit too small to subdivide)\n"); return 0; }
+  if (chunk == 0) { printf("  SKIP (limit too small to subdivide)\n"); return -1; }
 
   CUdeviceptr held[MAX_CHUNKS];
   int n = 0, oom = 0;
@@ -168,13 +168,13 @@ static capture_result_t capture_until_refused(CUstream stream, size_t chunk,
 /* [B] Several allocations inside ONE capture have to accumulate, or the check
  * can never fire and a capture can reserve without bound. */
 static int capture_allocations_accumulate(CUstream stream) {
-  if (!preloaded()) { printf("  SKIP (needs LD_PRELOAD=libvgpu-control.so)\n"); return 0; }
-  if (!ledger_enabled()) { printf("  SKIP (needs VMEMORY_NODE_ENABLED=1)\n"); return 0; }
+  if (!preloaded()) { printf("  SKIP (needs LD_PRELOAD=libvgpu-control.so)\n"); return -1; }
+  if (!ledger_enabled()) { printf("  SKIP (needs VMEMORY_NODE_ENABLED=1)\n"); return -1; }
 
   size_t freeb = 0;
   if (headroom(&freeb) != CUDA_SUCCESS) return 1;
   size_t chunk = freeb / 8;
-  if (chunk == 0) { printf("  SKIP (limit too small to subdivide)\n"); return 0; }
+  if (chunk == 0) { printf("  SKIP (limit too small to subdivide)\n"); return -1; }
 
   int granted = 0;
   capture_result_t outcome = capture_until_refused(stream, chunk, MAX_CHUNKS, &granted);
@@ -194,13 +194,13 @@ static int capture_allocations_accumulate(CUstream stream) {
  * in one pass, so drive many: each cycle charges a quarter of the limit, and a
  * charge that is never retired starves the fourth cycle onwards. */
 static int capture_charge_is_retired(CUstream stream) {
-  if (!preloaded()) { printf("  SKIP (needs LD_PRELOAD=libvgpu-control.so)\n"); return 0; }
-  if (!ledger_enabled()) { printf("  SKIP (needs VMEMORY_NODE_ENABLED=1)\n"); return 0; }
+  if (!preloaded()) { printf("  SKIP (needs LD_PRELOAD=libvgpu-control.so)\n"); return -1; }
+  if (!ledger_enabled()) { printf("  SKIP (needs VMEMORY_NODE_ENABLED=1)\n"); return -1; }
 
   size_t freeb = 0;
   if (headroom(&freeb) != CUDA_SUCCESS) return 1;
   size_t chunk = freeb / 4;
-  if (chunk == 0) { printf("  SKIP (limit too small to subdivide)\n"); return 0; }
+  if (chunk == 0) { printf("  SKIP (limit too small to subdivide)\n"); return -1; }
 
   for (int cycle = 1; cycle <= CAPTURE_CYCLES; cycle++) {
     CUresult r = cuStreamBeginCapture(stream, CU_STREAM_CAPTURE_MODE_RELAXED);
@@ -230,13 +230,13 @@ static int capture_charge_is_retired(CUstream stream) {
 /* [D] Retiring the same charge at both cuStreamEndCapture and cuGraphDestroy
  * must not credit it twice: the limit has to survive the round trip. */
 static int double_discharge_does_not_over_credit(CUstream stream) {
-  if (!preloaded()) { printf("  SKIP (needs LD_PRELOAD=libvgpu-control.so)\n"); return 0; }
-  if (!ledger_enabled()) { printf("  SKIP (needs VMEMORY_NODE_ENABLED=1)\n"); return 0; }
+  if (!preloaded()) { printf("  SKIP (needs LD_PRELOAD=libvgpu-control.so)\n"); return -1; }
+  if (!ledger_enabled()) { printf("  SKIP (needs VMEMORY_NODE_ENABLED=1)\n"); return -1; }
 
   size_t freeb = 0;
   if (headroom(&freeb) != CUDA_SUCCESS) return 1;
   size_t chunk = freeb / 4;
-  if (chunk == 0) { printf("  SKIP (limit too small to subdivide)\n"); return 0; }
+  if (chunk == 0) { printf("  SKIP (limit too small to subdivide)\n"); return -1; }
 
   /* One capture that goes through BOTH discharge points. */
   CUresult r = cuStreamBeginCapture(stream, CU_STREAM_CAPTURE_MODE_RELAXED);
@@ -283,23 +283,31 @@ int main(void) {
   CUstream stream;
   CHECK_DRV_API(cuStreamCreate(&stream, CU_STREAM_NON_BLOCKING));
 
-  int failures = 0;
+  int failures = 0, skipped = 0;
+  /* Each case returns 0 (passed), 1 (failed) or -1 (did not run). Skips are
+   * counted rather than folded into "passed" so the verdict cannot claim a
+   * coverage it never had -- see vgpu_test_verdict(). */
+  int rc;
+  #define RUN_CASE(title, call)                                               \
+    do {                                                                      \
+      printf(title "\n");                                                     \
+      rc = (call);                                                            \
+      if (rc < 0) skipped++; else failures += rc;                             \
+    } while (0)
 
-  printf("[A] a cuMemAllocAsync burst stops at the memory limit\n");
-  failures += async_burst_honours_limit(stream);
+  RUN_CASE("[A] a cuMemAllocAsync burst stops at the memory limit",
+           async_burst_honours_limit(stream));
+  RUN_CASE("[B] allocations inside one capture accumulate against the limit",
+           capture_allocations_accumulate(stream));
+  RUN_CASE("[C] the capture charge is retired at cuStreamEndCapture",
+           capture_charge_is_retired(stream));
+  RUN_CASE("[D] discharging at both end-of-capture and destroy does not over-credit",
+           double_discharge_does_not_over_credit(stream));
+  #undef RUN_CASE
 
-  printf("[B] allocations inside one capture accumulate against the limit\n");
-  failures += capture_allocations_accumulate(stream);
-
-  printf("[C] the capture charge is retired at cuStreamEndCapture\n");
-  failures += capture_charge_is_retired(stream);
-
-  printf("[D] discharging at both end-of-capture and destroy does not over-credit\n");
-  failures += double_discharge_does_not_over_credit(stream);
-
-  printf("\nResult: %s\n", failures ? "FAIL" : "PASS");
+  int verdict = vgpu_test_verdict(failures, skipped);
 
   cuStreamDestroy(stream);
   CHECK_DRV_API(cuCtxDestroy(ctx));
-  return failures ? 1 : 0;
+  return verdict;
 }

--- a/library/test/test_alloc_pool_async.c
+++ b/library/test/test_alloc_pool_async.c
@@ -130,6 +130,48 @@ static int explicit_pool_limit_test(CUdevice dev, CUstream stream) {
   return failed;
 }
 
+/* Allocate through the oversold UVA fallback and return the pointer it handed
+ * out, or 0 if the fallback was not reached.
+ *
+ * The fallback fires when the request would push past the PHYSICAL slice while
+ * still fitting the configured total (cuda_hook.c, MEMORY_PATH_UVA). main()
+ * arranges that window by setting CUDA_MEM_RATIO, which halves real_memory
+ * against the configured total; asking for 60% of the total therefore lands
+ * inside it. Requesting via cuMemAllocAsync is what makes the record an ASYNC
+ * one, which is what cuMemFreeAsync is paired with -- see the note in main().
+ *
+ * Whether the fallback actually fired is checked rather than assumed:
+ * CU_POINTER_ATTRIBUTE_IS_MANAGED distinguishes the managed pointer it returns
+ * from ordinary device memory, so a case built on the wrong kind of pointer
+ * reports that instead of asserting something unrelated. */
+static CUdeviceptr alloc_via_uva_fallback(CUstream stream) {
+  size_t freeb = 0, total = 0;
+  if (cuMemGetInfo(&freeb, &total) != CUDA_SUCCESS || total == 0) return 0;
+
+  size_t want = total / 10 * 6;
+  CUdeviceptr dptr = 0;
+  CUresult r = cuMemAllocAsync(&dptr, want, stream);
+  if (r != CUDA_SUCCESS) {
+    describe("cuMemAllocAsync (want UVA fallback)", r);
+    printf("  could not allocate %zu MiB of a %zu MiB total\n",
+           want / (1024 * 1024), total / (1024 * 1024));
+    return 0;
+  }
+
+  int managed = 0;
+  CUresult q = cuPointerGetAttribute(&managed, CU_POINTER_ATTRIBUTE_IS_MANAGED, dptr);
+  if (q != CUDA_SUCCESS || !managed) {
+    printf("  allocation of %zu MiB (total %zu MiB) came back as ordinary device\n"
+           "  memory, so the oversold UVA fallback was not reached -- is\n"
+           "  CUDA_MEM_RATIO still being applied?\n",
+           want / (1024 * 1024), total / (1024 * 1024));
+    cuMemFreeAsync(dptr, stream);
+    cuStreamSynchronize(stream);
+    return 0;
+  }
+  return dptr;
+}
+
 /* [D] Async-freeing a pointer that came from the oversold UVA fallback.
  *
  * Under memory oversubscription cuMemAllocAsync silently serves the request
@@ -138,22 +180,17 @@ static int explicit_pool_limit_test(CUdevice dev, CUstream stream) {
  * managed pointer with CUDA_ERROR_NOT_SUPPORTED, leaking both the allocation and
  * our vmem accounting (the hook only reconciles the accounting on success).
  *
- * Reaching that fallback needs an oversold config plus a request larger than the
- * physical slice, which a test cannot size portably. cuMemAllocManaged with
- * CU_MEM_ATTACH_GLOBAL registers the pointer in exactly the same virtual-memory
- * list, so it is a faithful stand-in for the pointer the fallback hands out.
- *
  * vgpu-manager specific: unhooked, cuMemFreeAsync on a managed pointer is simply
  * invalid, so this case only asserts under LD_PRELOAD. */
 static int uva_pointer_async_free_test(CUstream stream) {
   const char *preload = getenv("LD_PRELOAD");
   if (preload == NULL || strstr(preload, "libvgpu-control") == NULL) {
     printf("  SKIP (needs LD_PRELOAD=libvgpu-control.so)\n");
-    return 0;
+    return -1;
   }
 
-  CUdeviceptr dptr = 0;
-  CHECK_DRV_API(cuMemAllocManaged(&dptr, ALLOC_BYTES, CU_MEM_ATTACH_GLOBAL));
+  CUdeviceptr dptr = alloc_via_uva_fallback(stream);
+  if (dptr == 0) return 1;
   CUresult f = cuMemFreeAsync(dptr, stream);
   describe("cuMemFreeAsync (managed/UVA pointer)", f);
   if (f != CUDA_SUCCESS) {
@@ -187,11 +224,11 @@ static int uva_pointer_free_during_capture_test(CUstream stream) {
   const char *preload = getenv("LD_PRELOAD");
   if (preload == NULL || strstr(preload, "libvgpu-control") == NULL) {
     printf("  SKIP (needs LD_PRELOAD=libvgpu-control.so)\n");
-    return 0;
+    return -1;
   }
 
-  CUdeviceptr dptr = 0;
-  CHECK_DRV_API(cuMemAllocManaged(&dptr, ALLOC_BYTES, CU_MEM_ATTACH_GLOBAL));
+  CUdeviceptr dptr = alloc_via_uva_fallback(stream);
+  if (dptr == 0) return 1;
   CHECK_DRV_API(cuStreamBeginCapture(stream, CU_STREAM_CAPTURE_MODE_GLOBAL));
 
   CUresult f = cuMemFreeAsync(dptr, stream);
@@ -223,6 +260,29 @@ static int uva_pointer_free_during_capture_test(CUstream stream) {
 }
 
 int main(void) {
+  /* Open the oversold window that [D] and [E] need, before the first CUDA call.
+   *
+   * A ratio above 1 makes real_memory = total / ratio and turns oversubscription
+   * on (loader.c), so requests between real_memory and the configured total are
+   * served by the UVA fallback instead of being refused. Setting it here rather
+   * than in the runner keeps the effect to this binary; doing it before cuInit()
+   * is what makes it visible at all, since the library reads its configuration
+   * lazily on the first hooked call and deliberately installs no constructors
+   * (enforced by hack/check_no_constructors.sh).
+   *
+   * [A]-[C] are unaffected: they allocate far below real_memory, and the
+   * explicit-pool path passes allow_uva=0 so it still refuses rather than
+   * diverting to UVA.
+   *
+   * WHY the fallback has to be reached for real: the pointer's record type is
+   * what routes cuMemFreeAsync (MEMORY_TYPE_UVA_ASYNC -> the drain-and-cuMemFree
+   * path). cuMemAllocManaged, which these cases used to stand in with, records a
+   * SYNC pointer instead -- the type paired with cuMemFree -- so it stopped
+   * exercising the async release path once those types were introduced. That
+   * pairing mirrors CUDA's own rule that cuMemFreeAsync only accepts memory from
+   * cuMemAllocAsync, so the stand-in was the stale part, not the library. */
+  setenv("CUDA_MEM_RATIO", "2", 1);
+
   CHECK_DRV_API(cuInit(0));
   CUdevice device;
   CHECK_DRV_API(cuDeviceGet(&device, TEST_DEVICE_ID));
@@ -231,26 +291,32 @@ int main(void) {
   CUstream stream;
   CHECK_DRV_API(cuStreamCreate(&stream, CU_STREAM_NON_BLOCKING));
 
-  int failures = 0;
+  int failures = 0, skipped = 0;
+  /* Cases return 0 (passed), 1 (failed) or -1 (did not run); skips are counted
+   * apart from passes so the verdict cannot overstate what was checked. */
+  int rc;
+  #define RUN_CASE(title, call)                                               \
+    do {                                                                      \
+      printf(title "\n");                                                     \
+      rc = (call);                                                            \
+      if (rc < 0) skipped++; else failures += rc;                             \
+    } while (0)
 
-  printf("[A] cuMemAllocAsync + cuMemFreeAsync (default pool)\n");
-  failures += default_pool_async_test(stream);
+  RUN_CASE("[A] cuMemAllocAsync + cuMemFreeAsync (default pool)",
+           default_pool_async_test(stream));
+  RUN_CASE("[B] cuMemAllocFromPoolAsync + cuMemFreeAsync (explicit pool)",
+           explicit_pool_async_test(device, stream));
+  RUN_CASE("[C] cuMemAllocFromPoolAsync honours the memory limit",
+           explicit_pool_limit_test(device, stream));
+  RUN_CASE("[D] cuMemFreeAsync accepts an oversold UVA pointer",
+           uva_pointer_async_free_test(stream));
+  RUN_CASE("[E] cuMemFreeAsync refuses a UVA pointer mid-capture",
+           uva_pointer_free_during_capture_test(stream));
+  #undef RUN_CASE
 
-  printf("[B] cuMemAllocFromPoolAsync + cuMemFreeAsync (explicit pool)\n");
-  failures += explicit_pool_async_test(device, stream);
-
-  printf("[C] cuMemAllocFromPoolAsync honours the memory limit\n");
-  failures += explicit_pool_limit_test(device, stream);
-
-  printf("[D] cuMemFreeAsync accepts an oversold UVA pointer\n");
-  failures += uva_pointer_async_free_test(stream);
-
-  printf("[E] cuMemFreeAsync refuses a UVA pointer mid-capture\n");
-  failures += uva_pointer_free_during_capture_test(stream);
-
-  printf("\nResult: %s\n", failures ? "FAIL" : "PASS");
+  int verdict = vgpu_test_verdict(failures, skipped);
 
   cuStreamDestroy(stream);
   CHECK_DRV_API(cuCtxDestroy(ctx));
-  return failures ? 1 : 0;
+  return verdict;
 }

--- a/library/test/test_alloc_pool_async.c
+++ b/library/test/test_alloc_pool_async.c
@@ -39,8 +39,16 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>    /* unlink */
+#include <errno.h>
 
 #include "test_utils.h"
+
+/* The library caches its configuration here and only falls back to the
+ * environment when the file is absent (loader.c, load_controller_configuration:
+ * mmap the file, else build from env and write it back). Cases [D]/[E] depend
+ * on that fallback running, see main(). */
+#define VGPU_CONFIG_FILE "/etc/vgpu-manager/config/vgpu.config"
 
 #define ALLOC_BYTES  (32ull * 1024 * 1024)  /* 32 MiB */
 #define OVER_LIMIT   (1024ull * 1024 * 1024) /* how far past `free` case [C] asks */
@@ -162,8 +170,11 @@ static CUdeviceptr alloc_via_uva_fallback(CUstream stream) {
   CUresult q = cuPointerGetAttribute(&managed, CU_POINTER_ATTRIBUTE_IS_MANAGED, dptr);
   if (q != CUDA_SUCCESS || !managed) {
     printf("  allocation of %zu MiB (total %zu MiB) came back as ordinary device\n"
-           "  memory, so the oversold UVA fallback was not reached -- is\n"
-           "  CUDA_MEM_RATIO still being applied?\n",
+           "  memory, so the oversold UVA fallback was not reached.\n"
+           "  The window is real_memory..total, and CUDA_MEM_RATIO=2 is what\n"
+           "  halves real_memory -- check that " VGPU_CONFIG_FILE "\n"
+           "  was removed before cuInit(), since a config file left by an\n"
+           "  earlier test makes the library ignore the environment entirely.\n",
            want / (1024 * 1024), total / (1024 * 1024));
     cuMemFreeAsync(dptr, stream);
     cuStreamSynchronize(stream);
@@ -259,16 +270,31 @@ static int uva_pointer_free_during_capture_test(CUstream stream) {
   return failed;
 }
 
+/* Leave no ratio behind: the next test binary must build its configuration from
+ * the runner's environment, not from ours. A failure here is worth reporting --
+ * it means [D]/[E] are about to run against somebody else's configuration. */
+static void drop_cached_config(void) {
+  if (unlink(VGPU_CONFIG_FILE) != 0 && errno != ENOENT) {
+    printf("  [warn] could not remove %s: %s\n", VGPU_CONFIG_FILE, strerror(errno));
+  }
+}
+
 int main(void) {
   /* Open the oversold window that [D] and [E] need, before the first CUDA call.
    *
    * A ratio above 1 makes real_memory = total / ratio and turns oversubscription
    * on (loader.c), so requests between real_memory and the configured total are
-   * served by the UVA fallback instead of being refused. Setting it here rather
-   * than in the runner keeps the effect to this binary; doing it before cuInit()
-   * is what makes it visible at all, since the library reads its configuration
-   * lazily on the first hooked call and deliberately installs no constructors
-   * (enforced by hack/check_no_constructors.sh).
+   * served by the UVA fallback instead of being refused.
+   *
+   * Both steps below are required. Setting the variable alone does nothing:
+   * tests run in sequence, and by the time this binary starts an earlier one has
+   * already written the config file from the runner's environment, after which
+   * the environment is never consulted again. Removing the file first is what
+   * sends this process down the env path; the library reads it lazily on the
+   * first hooked call and installs no constructors (enforced by
+   * hack/check_no_constructors.sh), so doing this before cuInit() is in time.
+   * The file is removed again on exit so the ratio does not leak into the tests
+   * that run after this one.
    *
    * [A]-[C] are unaffected: they allocate far below real_memory, and the
    * explicit-pool path passes allow_uva=0 so it still refuses rather than
@@ -281,7 +307,9 @@ int main(void) {
    * exercising the async release path once those types were introduced. That
    * pairing mirrors CUDA's own rule that cuMemFreeAsync only accepts memory from
    * cuMemAllocAsync, so the stand-in was the stale part, not the library. */
+  drop_cached_config();
   setenv("CUDA_MEM_RATIO", "2", 1);
+  atexit(drop_cached_config);
 
   CHECK_DRV_API(cuInit(0));
   CUdevice device;

--- a/library/test/test_utils.h
+++ b/library/test/test_utils.h
@@ -27,6 +27,28 @@
 #define TEST_DEVICE_ID 0
 #endif
 
+/* Exit status meaning "this test did not actually run" (the autotools
+ * convention, recognised by run_all_tests.sh).
+ *
+ * A case that cannot meet its preconditions must not return 0. Reporting
+ * success for assertions that never executed makes a skipped test
+ * indistinguishable from a passing one in the summary, which is exactly how a
+ * regression survives a green run. Tests count their skips and exit with this
+ * instead; run_tests_with_env.sh additionally sets VGPU_TEST_STRICT=1, under
+ * which the runner treats any skip as a failure because it configured
+ * everything the tests were promised. */
+#define VGPU_TEST_RC_SKIP 77
+
+/* Final verdict for a test with `failures` failed and `skipped` skipped cases.
+ * Failure wins over skip: a run that both failed and skipped is a failure. */
+static inline int vgpu_test_verdict(int failures, int skipped) {
+  printf("\nResult: %s", failures ? "FAIL" : (skipped ? "SKIP" : "PASS"));
+  if (skipped) printf("  (%d case(s) skipped -- assertions did NOT run)", skipped);
+  printf("\n");
+  if (failures) return 1;
+  return skipped ? VGPU_TEST_RC_SKIP : 0;
+}
+
 #define CHECK_RUNTIME_API(f)                                                  \
   do {                                                                        \
     cudaError_t _status = (f);                                                \

--- a/pkg/config/node/node_config.go
+++ b/pkg/config/node/node_config.go
@@ -47,6 +47,7 @@ type NodeConfigSpec struct {
 	nodeConfigPath   string
 	driverRoot       *nvidia.RootPath
 	hostDriverRoot   *nvidia.RootPath
+	hostDevRoot      *nvidia.RootPath
 	checkFields      bool
 }
 
@@ -164,6 +165,13 @@ func (nc NodeConfigSpec) GetHostDriverRoot() nvidia.RootPath {
 		return "/"
 	}
 	return *nc.hostDriverRoot
+}
+
+func (nc NodeConfigSpec) GetHostDevRoot() nvidia.RootPath {
+	if nc.hostDevRoot == nil {
+		return "/"
+	}
+	return *nc.hostDevRoot
 }
 
 func (nc NodeConfigSpec) YamlString() string {
@@ -359,6 +367,12 @@ func WithDriverRootOption(driverRoot nvidia.RootPath) Option {
 func WithHostDriverRootOption(driverRoot nvidia.RootPath) Option {
 	return func(spec *NodeConfigSpec) {
 		spec.hostDriverRoot = &driverRoot
+	}
+}
+
+func WithHostDevRootOption(devRoot nvidia.RootPath) Option {
+	return func(spec *NodeConfigSpec) {
+		spec.hostDevRoot = &devRoot
 	}
 }
 

--- a/pkg/deviceplugin/cdi/api.go
+++ b/pkg/deviceplugin/cdi/api.go
@@ -1,5 +1,7 @@
 package cdi
 
+import "k8s.io/klog/v2"
+
 // Handler generates the node CDI specification and builds the CDI references
 // (annotations / CDI devices) that are returned to kubelet during Allocate.
 type Handler interface {
@@ -12,6 +14,7 @@ type Handler interface {
 	// GetDeviceAnnotations builds the CDI container annotations for the given
 	// qualified device names, honoring the configured annotation prefix.
 	GetDeviceAnnotations(responseID string, qualifiedNames []string) (map[string]string, error)
+	AdditionalDevices() []string
 }
 
 // null is a no-op Handler used when no CDI strategy is enabled.
@@ -27,9 +30,14 @@ func (n *null) CreateSpecFile() error {
 }
 
 func (n *null) QualifiedName(_, _ string) string {
+	klog.Error("cannot return a qualified CDI device name with the null CDI handler")
 	return ""
 }
 
 func (n *null) GetDeviceAnnotations(_ string, _ []string) (map[string]string, error) {
 	return nil, nil
+}
+
+func (n *null) AdditionalDevices() []string {
+	return nil
 }

--- a/pkg/deviceplugin/cdi/cdi.go
+++ b/pkg/deviceplugin/cdi/cdi.go
@@ -6,10 +6,13 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/NVIDIA/go-nvlib/pkg/nvlib/device"
+	"github.com/NVIDIA/go-nvlib/pkg/nvlib/info"
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 	"github.com/NVIDIA/nvidia-container-toolkit/pkg/nvcdi"
-	"github.com/NVIDIA/nvidia-container-toolkit/pkg/nvcdi/spec"
+	"github.com/NVIDIA/nvidia-container-toolkit/pkg/nvcdi/transform"
 	transformroot "github.com/NVIDIA/nvidia-container-toolkit/pkg/nvcdi/transform/root"
+	"github.com/coldzerofear/vgpu-manager/pkg/device/imex"
 	"github.com/coldzerofear/vgpu-manager/pkg/device/nvidia"
 	"github.com/coldzerofear/vgpu-manager/pkg/util"
 	"github.com/sirupsen/logrus"
@@ -47,23 +50,40 @@ type Config struct {
 	DevRoot string
 	// TargetDriverRoot is the driver root on the host (written into the spec).
 	TargetDriverRoot string
+	TargetDevRoot    string
+
+	GDSEnabled     bool
+	MOFEDEnabled   bool
+	GDRCopyEnabled bool
+
+	ImexChannels imex.Channels
 }
 
 type handler struct {
+	infolib          info.Interface
 	nvmllib          nvml.Interface
-	cdilib           nvcdi.Interface
+	devicelib        device.Interface
+	logger           *logrus.Logger
 	vendor           string
 	class            string
 	annotationPrefix string
 	driverRoot       string
 	devRoot          string
 	targetDriverRoot string
+	targetDevRoot    string
+	cdilibs          map[string]nvcdi.SpecGenerator
+	additionalModes  []string
 }
 
 // New builds a CDI Handler. When no CDI strategy is enabled a null Handler is
 // returned so callers can use it unconditionally.
 func New(devicelib *nvidia.DeviceLib, cfg Config) (Handler, error) {
 	if !cfg.Strategies.AnyCDIEnabled() {
+		return NewNullHandler(), nil
+	}
+	hasNVML, _ := devicelib.HasNvml()
+	if !hasNVML {
+		klog.Warning("No valid resources detected, creating a null CDI handler")
 		return NewNullHandler(), nil
 	}
 
@@ -91,6 +111,9 @@ func New(devicelib *nvidia.DeviceLib, cfg Config) (Handler, error) {
 	if cfg.TargetDriverRoot == "" {
 		cfg.TargetDriverRoot = cfg.DriverRoot
 	}
+	if cfg.TargetDevRoot == "" {
+		cfg.TargetDevRoot = cfg.DevRoot
+	}
 
 	deviceNamer, err := nvcdi.NewDeviceNamer(cfg.DeviceIDStrategy)
 	if err != nil {
@@ -104,7 +127,9 @@ func New(devicelib *nvidia.DeviceLib, cfg Config) (Handler, error) {
 		cdilogger.SetOutput(io.Discard)
 	}
 
-	cdilib, err := nvcdi.New(
+	cdilibs := make(map[string]nvcdi.SpecGenerator)
+
+	cdilibs["gpu"], err = nvcdi.New(
 		nvcdi.WithDeviceLib(devicelib),
 		nvcdi.WithInfoLib(devicelib),
 		nvcdi.WithNvmlLib(devicelib),
@@ -120,15 +145,54 @@ func New(devicelib *nvidia.DeviceLib, cfg Config) (Handler, error) {
 		return nil, fmt.Errorf("failed to create nvcdi library: %w", err)
 	}
 
+	if len(cfg.ImexChannels) > 0 {
+		cdilibs["imex-channel"] = &imexChannelCDILib{
+			vendor:       cfg.Vendor,
+			imexChannels: cfg.ImexChannels,
+		}
+	}
+
+	var additionalModes []string
+	if cfg.GDRCopyEnabled {
+		additionalModes = append(additionalModes, "gdrcopy")
+	}
+	if cfg.GDSEnabled {
+		additionalModes = append(additionalModes, "gds")
+	}
+	if cfg.MOFEDEnabled {
+		additionalModes = append(additionalModes, "mofed")
+	}
+
+	for _, mode := range additionalModes {
+		lib, err := nvcdi.New(
+			nvcdi.WithInfoLib(devicelib),
+			nvcdi.WithLogger(cdilogger),
+			nvcdi.WithNVIDIACDIHookPath(cfg.NvidiaCDIHookPath),
+			nvcdi.WithDriverRoot(cfg.DriverRoot),
+			nvcdi.WithDevRoot(cfg.DevRoot),
+			nvcdi.WithVendor(cfg.Vendor),
+			nvcdi.WithMode(mode),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create nvcdi library: %v", err)
+		}
+		cdilibs[mode] = lib
+	}
+
 	return &handler{
+		infolib:          devicelib,
+		devicelib:        devicelib,
 		nvmllib:          devicelib,
-		cdilib:           cdilib,
+		cdilibs:          cdilibs,
 		vendor:           cfg.Vendor,
 		class:            cfg.Class,
+		logger:           cdilogger,
 		annotationPrefix: cfg.AnnotationPrefix,
 		driverRoot:       cfg.DriverRoot,
 		devRoot:          cfg.DevRoot,
 		targetDriverRoot: cfg.TargetDriverRoot,
+		targetDevRoot:    cfg.TargetDevRoot,
+		additionalModes:  additionalModes,
 	}, nil
 }
 
@@ -144,15 +208,18 @@ func (h *handler) GetDeviceAnnotations(responseID string, qualifiedNames []strin
 	if err != nil {
 		return nil, fmt.Errorf("failed to build CDI annotations: %w", err)
 	}
+
 	if h.annotationPrefix == cdiapi.AnnotationPrefix {
 		return annotations, nil
 	}
-	updated := make(map[string]string, len(annotations))
+
+	// update annotations if a custom CDI prefix is configured
+	updatedAnnotations := make(map[string]string, len(annotations))
 	for k, v := range annotations {
 		newKey := h.annotationPrefix + strings.TrimPrefix(k, cdiapi.AnnotationPrefix)
-		updated[newKey] = v
+		updatedAnnotations[newKey] = v
 	}
-	return updated, nil
+	return updatedAnnotations, nil
 }
 
 // CreateSpecFile generates and writes the CDI specification for the node's GPUs.
@@ -164,36 +231,77 @@ func (h *handler) CreateSpecFile() error {
 	}
 	defer func() { _ = h.nvmllib.Shutdown() }()
 
-	klog.InfoS("Generating CDI specification", "vendor", h.vendor, "class", h.class)
-	spec, err := h.cdilib.GetSpec()
-	if err != nil {
-		return fmt.Errorf("failed to get CDI spec: %w", err)
+	var emptySpecs []string
+	for class, cdilib := range h.cdilibs {
+		h.logger.Infof("Generating CDI spec for resource: %s/%s", h.vendor, class)
+		spec, err := cdilib.GetSpec()
+		if err != nil {
+			return fmt.Errorf("failed to get CDI spec: %v", err)
+		}
+		// TODO: Once the NewDriverTransformer is merged in container-toolkit we can instantiate it directly.
+		transformer := h.getRootTransformer()
+		if err := transformer.Transform(spec.Raw()); err != nil {
+			return fmt.Errorf("failed to transform driver root in CDI spec: %v", err)
+		}
+
+		specName, err := cdiapi.GenerateNameForSpec(spec.Raw())
+		if err != nil {
+			return fmt.Errorf("failed to generate CDI spec name: %w", err)
+		}
+		h.logger.Infof("Write CDI spec: %s", specName)
+		specPath := filepath.Join(cdiRoot, specName+".json")
+		if err = spec.Save(specPath); err != nil {
+			// TODO: This is a brittle check since it relies on exact string matches.
+			// We should pull this functionality into the CDI tooling instead.
+			if strings.Contains(err.Error(), "invalid device, empty device edits") {
+				klog.ErrorS(err, "Ignoring empty CDI specs", "vendor", h.vendor, "class", class)
+				emptySpecs = append(emptySpecs, class)
+				continue
+			}
+			return fmt.Errorf("failed to save CDI spec %q: %w", specPath, err)
+		}
+		h.logger.Infoln("Generated CDI specification", "path", specPath)
 	}
-	if err = h.writeSpec(spec); err != nil {
-		return fmt.Errorf("failed to write spec: %w", err)
+	// Remove the classes with empty specs from the supported types.
+	for _, emptySpec := range emptySpecs {
+		delete(h.cdilibs, emptySpec)
 	}
 	return nil
 }
 
-func (h *handler) writeSpec(spec spec.Interface) error {
-	// Transform the spec to make it aware that it is running inside a container.
-	err := transformroot.New(
+// getRootTransformer rewrites the driver/dev root paths in the generated spec
+// from the plugin's view to the host's view. Mirrors the NVIDIA device plugin.
+func (h *handler) getRootTransformer() transform.Transformer {
+	driverRootTransformer := transformroot.New(
 		transformroot.WithRoot(h.driverRoot),
 		transformroot.WithTargetRoot(h.targetDriverRoot),
 		transformroot.WithRelativeTo("host"),
-	).Transform(spec.Raw())
-	if err != nil {
-		return fmt.Errorf("failed to transform driver root in CDI spec: %w", err)
+	)
+	if h.devRoot == h.driverRoot || h.devRoot == "" {
+		return driverRootTransformer
 	}
-	specName, err := cdiapi.GenerateNameForSpec(spec.Raw())
-	if err != nil {
-		return fmt.Errorf("failed to generate CDI spec name: %w", err)
+	ensureDev := func(p string) string {
+		return filepath.Join(strings.TrimSuffix(filepath.Clean(p), "/dev"), "/dev")
 	}
-	klog.V(3).Infof("Write CDI spec: %s", specName)
-	specPath := filepath.Join(cdiRoot, specName+".yaml")
-	if err = spec.Save(specPath); err != nil {
-		return fmt.Errorf("failed to save CDI spec %q: %w", specPath, err)
+	devRootTransformer := transformroot.New(
+		transformroot.WithRoot(ensureDev(h.devRoot)),
+		transformroot.WithTargetRoot(ensureDev(h.targetDevRoot)),
+		transformroot.WithRelativeTo("host"),
+	)
+	return transform.Merge(driverRootTransformer, devRootTransformer)
+}
+
+// AdditionalDevices returns the optional CDI devices based on the device plugin
+// configuration.
+// Here we check for requested modes as well as whether the modes have a valid
+// CDI spec associated with them.
+func (h *handler) AdditionalDevices() []string {
+	var devices []string
+	for _, mode := range h.additionalModes {
+		if h.cdilibs[mode] == nil {
+			continue
+		}
+		devices = append(devices, h.QualifiedName(mode, "all"))
 	}
-	klog.InfoS("Generated CDI specification", "path", specPath)
-	return nil
+	return devices
 }

--- a/pkg/deviceplugin/cdi/cdi.go
+++ b/pkg/deviceplugin/cdi/cdi.go
@@ -63,7 +63,6 @@ type handler struct {
 	infolib          info.Interface
 	nvmllib          nvml.Interface
 	devicelib        device.Interface
-	logger           *logrus.Logger
 	vendor           string
 	class            string
 	annotationPrefix string
@@ -186,7 +185,6 @@ func New(devicelib *nvidia.DeviceLib, cfg Config) (Handler, error) {
 		cdilibs:          cdilibs,
 		vendor:           cfg.Vendor,
 		class:            cfg.Class,
-		logger:           cdilogger,
 		annotationPrefix: cfg.AnnotationPrefix,
 		driverRoot:       cfg.DriverRoot,
 		devRoot:          cfg.DevRoot,
@@ -226,14 +224,20 @@ func (h *handler) GetDeviceAnnotations(responseID string, qualifiedNames []strin
 // It manages its own NVML lifecycle so it is safe to call regardless of whether
 // NVML has been initialized elsewhere.
 func (h *handler) CreateSpecFile() error {
-	if ret := h.nvmllib.Init(); ret != nvml.SUCCESS {
-		return fmt.Errorf("failed to initialize NVML for CDI spec generation: %v", ret)
-	}
-	defer func() { _ = h.nvmllib.Shutdown() }()
-
 	var emptySpecs []string
 	for class, cdilib := range h.cdilibs {
-		h.logger.Infof("Generating CDI spec for resource: %s/%s", h.vendor, class)
+		klog.V(3).Infof("Generating CDI spec for resource: %s/%s", h.vendor, class)
+
+		if class == "gpu" {
+			ret := h.nvmllib.Init()
+			if ret != nvml.SUCCESS {
+				return fmt.Errorf("failed to initialize NVML: %v", ret)
+			}
+			defer func() {
+				_ = h.nvmllib.Shutdown()
+			}()
+		}
+
 		spec, err := cdilib.GetSpec()
 		if err != nil {
 			return fmt.Errorf("failed to get CDI spec: %v", err)
@@ -248,7 +252,7 @@ func (h *handler) CreateSpecFile() error {
 		if err != nil {
 			return fmt.Errorf("failed to generate CDI spec name: %w", err)
 		}
-		h.logger.Infof("Write CDI spec: %s", specName)
+		klog.V(3).Infof("Write CDI spec: %s", specName)
 		specPath := filepath.Join(cdiRoot, specName+".json")
 		if err = spec.Save(specPath); err != nil {
 			// TODO: This is a brittle check since it relies on exact string matches.
@@ -260,7 +264,7 @@ func (h *handler) CreateSpecFile() error {
 			}
 			return fmt.Errorf("failed to save CDI spec %q: %w", specPath, err)
 		}
-		h.logger.Infoln("Generated CDI specification", "path", specPath)
+		klog.V(3).Infoln("Generated CDI specification", "path", specPath)
 	}
 	// Remove the classes with empty specs from the supported types.
 	for _, emptySpec := range emptySpecs {

--- a/pkg/deviceplugin/cdi/imex.go
+++ b/pkg/deviceplugin/cdi/imex.go
@@ -1,21 +1,18 @@
-/*
- * Licensed to NVIDIA CORPORATION under one or more contributor
- * license agreements. See the NOTICE file distributed with
- * this work for additional information regarding copyright
- * ownership. NVIDIA CORPORATION licenses this file to you under
- * the Apache License, Version 2.0 (the "License"); you may
- * not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
+/**
+# Copyright 2024 NVIDIA CORPORATION
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+**/
 
 package cdi
 

--- a/pkg/deviceplugin/cdi/imex.go
+++ b/pkg/deviceplugin/cdi/imex.go
@@ -1,0 +1,56 @@
+/*
+ * Licensed to NVIDIA CORPORATION under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. NVIDIA CORPORATION licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package cdi
+
+import (
+	"github.com/coldzerofear/vgpu-manager/pkg/device/imex"
+	"tags.cncf.io/container-device-interface/specs-go"
+
+	"github.com/NVIDIA/nvidia-container-toolkit/pkg/nvcdi/spec"
+)
+
+type imexChannelCDILib struct {
+	vendor       string
+	imexChannels imex.Channels
+}
+
+// GetSpec returns the CDI specs for IMEX channels.
+func (l *imexChannelCDILib) GetSpec(...string) (spec.Interface, error) {
+	var deviceSpecs []specs.Device
+	for _, channel := range l.imexChannels {
+		deviceSpec := specs.Device{
+			Name: channel.ID,
+			ContainerEdits: specs.ContainerEdits{
+				DeviceNodes: []*specs.DeviceNode{
+					{
+						Path:     channel.Path,
+						HostPath: channel.HostPath,
+					},
+				},
+			},
+		}
+		deviceSpecs = append(deviceSpecs, deviceSpec)
+	}
+	return spec.New(
+		spec.WithDeviceSpecs(deviceSpecs),
+		spec.WithVendor(l.vendor),
+		spec.WithClass("imex-channel"),
+	)
+}

--- a/pkg/deviceplugin/factory.go
+++ b/pkg/deviceplugin/factory.go
@@ -49,9 +49,10 @@ func GetDevicePlugins(
 			// The host driver/dev root is mounted into the plugin at the same path,
 			// so the in-container read path equals the host path written into the
 			// spec (TargetDriverRoot/TargetDevRoot default to these in cdi.New).
-			DriverRoot:       option.ContainerDriverRoot,
-			TargetDriverRoot: option.HostDriverRoot,
-			DevRoot:          devManager.DevRoot,
+			DriverRoot:       string(nodeConfig.GetDriverRoot()),
+			TargetDriverRoot: string(nodeConfig.GetHostDriverRoot()),
+			DevRoot:          nodeConfig.GetDriverRoot().GetDevRoot(),
+			TargetDevRoot:    string(nodeConfig.GetHostDevRoot()),
 			GDSEnabled:       nodeConfig.GetGDSEnabled(),
 			MOFEDEnabled:     nodeConfig.GetMOFEDEnabled(),
 			GDRCopyEnabled:   nodeConfig.GetGDRCopyEnabled(),

--- a/pkg/deviceplugin/factory.go
+++ b/pkg/deviceplugin/factory.go
@@ -52,6 +52,10 @@ func GetDevicePlugins(
 			DriverRoot:       option.ContainerDriverRoot,
 			TargetDriverRoot: option.HostDriverRoot,
 			DevRoot:          devManager.DevRoot,
+			GDSEnabled:       nodeConfig.GetGDSEnabled(),
+			MOFEDEnabled:     nodeConfig.GetMOFEDEnabled(),
+			GDRCopyEnabled:   nodeConfig.GetGDRCopyEnabled(),
+			ImexChannels:     devManager.GetImexChannels(),
 		})
 	if err != nil {
 		klog.Errorf("Create CDI handler failed: %v", err)

--- a/pkg/deviceplugin/mig/mig_plugin.go
+++ b/pkg/deviceplugin/mig/mig_plugin.go
@@ -119,7 +119,7 @@ func (m *migDevicePlugin) Allocate(_ context.Context, req *pluginapi.AllocateReq
 				})
 			}
 		}
-		if err := vgpu.UpdateResponseForCDI(responses[i], strategies, m.cdiHandler, deviceIds...); err != nil {
+		if err := vgpu.UpdateResponseForCDI(deviceManager.GetImexChannels(), responses[i], strategies, m.cdiHandler, deviceIds...); err != nil {
 			err = fmt.Errorf("failed to get allocate response for CDI: %v", err)
 			klog.Errorln(err)
 			return nil, err

--- a/pkg/deviceplugin/vgpu/cdi_response_test.go
+++ b/pkg/deviceplugin/vgpu/cdi_response_test.go
@@ -23,6 +23,10 @@ func (f fakeCDIHandler) GetDeviceAnnotations(responseID string, names []string) 
 	return map[string]string{"cdi.k8s.io/vgpu-manager_" + responseID: strings.Join(names, ",")}, nil
 }
 
+func (f fakeCDIHandler) AdditionalDevices() []string {
+	return nil
+}
+
 var _ cdi.Handler = fakeCDIHandler{}
 
 func newResp() *pluginapi.ContainerAllocateResponse {
@@ -31,7 +35,7 @@ func newResp() *pluginapi.ContainerAllocateResponse {
 
 func Test_UpdateResponseForCDI_NoCDIStrategy(t *testing.T) {
 	resp := newResp()
-	err := UpdateResponseForCDI(resp, util.DeviceListStrategies{util.DeviceListStrategyEnvvar},
+	err := UpdateResponseForCDI(nil, resp, util.DeviceListStrategies{util.DeviceListStrategyEnvvar},
 		fakeCDIHandler{}, "GPU-1", "GPU-2")
 	assert.NoError(t, err)
 	assert.Empty(t, resp.Annotations)
@@ -40,7 +44,7 @@ func Test_UpdateResponseForCDI_NoCDIStrategy(t *testing.T) {
 
 func Test_UpdateResponseForCDI_Annotations(t *testing.T) {
 	resp := newResp()
-	err := UpdateResponseForCDI(resp, util.DeviceListStrategies{util.DeviceListStrategyCDIAnnotations},
+	err := UpdateResponseForCDI(nil, resp, util.DeviceListStrategies{util.DeviceListStrategyCDIAnnotations},
 		fakeCDIHandler{}, "GPU-1", "GPU-2")
 	assert.NoError(t, err)
 	assert.Len(t, resp.Annotations, 1)
@@ -53,7 +57,7 @@ func Test_UpdateResponseForCDI_Annotations(t *testing.T) {
 
 func Test_UpdateResponseForCDI_CRI(t *testing.T) {
 	resp := newResp()
-	err := UpdateResponseForCDI(resp, util.DeviceListStrategies{util.DeviceListStrategyCDICRI},
+	err := UpdateResponseForCDI(nil, resp, util.DeviceListStrategies{util.DeviceListStrategyCDICRI},
 		fakeCDIHandler{}, "GPU-1", "GPU-2")
 	assert.NoError(t, err)
 	assert.Empty(t, resp.Annotations)
@@ -64,7 +68,7 @@ func Test_UpdateResponseForCDI_CRI(t *testing.T) {
 
 func Test_UpdateResponseForCDI_Combined(t *testing.T) {
 	resp := newResp()
-	err := UpdateResponseForCDI(resp,
+	err := UpdateResponseForCDI(nil, resp,
 		util.DeviceListStrategies{util.DeviceListStrategyCDIAnnotations, util.DeviceListStrategyCDICRI},
 		fakeCDIHandler{}, "GPU-1")
 	assert.NoError(t, err)

--- a/pkg/deviceplugin/vgpu/vnum_plugin.go
+++ b/pkg/deviceplugin/vgpu/vnum_plugin.go
@@ -603,6 +603,7 @@ func UpdateResponseForNodeConfig(
 // (e.g. "gpu") and deviceIDs are the device UUIDs to expose. It is a no-op when
 // no CDI strategy is enabled.
 func UpdateResponseForCDI(
+	imexChannels imex.Channels,
 	response *pluginapi.ContainerAllocateResponse,
 	strategies util.DeviceListStrategies,
 	handler cdi.Handler, deviceIDs ...string,
@@ -614,8 +615,20 @@ func UpdateResponseForCDI(
 	for i, id := range deviceIDs {
 		qualifiedNames[i] = handler.QualifiedName(util.CDIClass, id)
 	}
+
+	for _, channel := range imexChannels {
+		qualifiedNames = append(qualifiedNames, handler.QualifiedName("imex-channel", channel.ID))
+	}
+
+	qualifiedNames = append(qualifiedNames, handler.AdditionalDevices()...)
+
+	if len(qualifiedNames) == 0 {
+		return nil
+	}
+
 	if strategies.Includes(util.DeviceListStrategyCDIAnnotations) {
-		annotations, err := handler.GetDeviceAnnotations(uuid.New().String(), qualifiedNames)
+		responseID := uuid.New().String()
+		annotations, err := handler.GetDeviceAnnotations(responseID, qualifiedNames)
 		if err != nil {
 			return err
 		}
@@ -625,8 +638,11 @@ func UpdateResponseForCDI(
 		maps.Copy(response.Annotations, annotations)
 	}
 	if strategies.Includes(util.DeviceListStrategyCDICRI) {
-		for _, name := range qualifiedNames {
-			response.CdiDevices = append(response.CdiDevices, &pluginapi.CDIDevice{Name: name})
+		for _, device := range qualifiedNames {
+			cdiDevice := pluginapi.CDIDevice{
+				Name: device,
+			}
+			response.CdiDevices = append(response.CdiDevices, &cdiDevice)
 		}
 	}
 	return nil
@@ -698,6 +714,7 @@ func (m *vNumberDevicePlugin) Allocate(ctx context.Context, req *pluginapi.Alloc
 	memoryRatio := deviceManager.GetNodeConfig().GetDeviceMemoryScaling()
 	enabledSMWatcher := deviceManager.GetFeatureGate().Enabled(util.SMWatcher)
 	enabledClientMode := deviceManager.GetFeatureGate().Enabled(util.ClientMode)
+	enabledMemoryNode := deviceManager.GetFeatureGate().Enabled(util.VMemoryNode)
 
 	for i, containerRequest := range req.ContainerRequests {
 		contClaim, err = device.GetCurrentPreAllocateContainerDevice(currentPod)
@@ -736,8 +753,8 @@ func (m *vNumberDevicePlugin) Allocate(ctx context.Context, req *pluginapi.Alloc
 		response.Envs[util.CudaCoreLimitEnv] = ""
 		response.Envs[util.CudaSoftCoreLimitEnv] = ""
 		response.Envs[util.ManagerClientRegisterUuid] = ""
-		mode := vgpu.GetCompatibilityMode(deviceManager)
-		response.Envs[util.ManagerCompatibilityMode] = fmt.Sprintf("%v", mode)
+		compMode := vgpu.GetCompatibilityMode(deviceManager)
+		response.Envs[util.ManagerCompatibilityMode] = fmt.Sprintf("%v", compMode)
 		sort.Slice(contClaim.DeviceClaims, func(i, j int) bool {
 			return contClaim.DeviceClaims[i].Id < contClaim.DeviceClaims[j].Id
 		})
@@ -773,7 +790,7 @@ func (m *vNumberDevicePlugin) Allocate(ctx context.Context, req *pluginapi.Alloc
 			}
 		}
 		response.Envs[util.ManagerVisibleDevices] = strings.Join(deviceUuids, ",")
-		if err = UpdateResponseForCDI(response, strategies, m.cdiHandler, deviceIds...); err != nil {
+		if err = UpdateResponseForCDI(deviceManager.GetImexChannels(), response, strategies, m.cdiHandler, deviceIds...); err != nil {
 			klog.V(3).ErrorS(err, "failed to update allocate response for CDI",
 				"pod", klog.KObj(currentPod), "container", contClaim.Name, "reqIndex", i)
 			return resp, err
@@ -802,6 +819,9 @@ func (m *vNumberDevicePlugin) Allocate(ctx context.Context, req *pluginapi.Alloc
 				HostPath:      HostWatcherDirectoryPath,
 				ReadOnly:      true,
 			})
+		}
+		if enabledMemoryNode {
+			response.Envs[util.VMemoryNodeEnabled] = "true"
 		}
 		// /etc/vgpu-manager/<pod-uid>_<cont-name>
 		// <host_manager_dir>/<pod-uid>_<cont-name>

--- a/pkg/deviceplugin/vgpu/vnum_plugin.go
+++ b/pkg/deviceplugin/vgpu/vnum_plugin.go
@@ -517,7 +517,7 @@ func apiDeviceSpecs(devManager *manager.DeviceManager, devices []manager.Device)
 	}
 
 	var specs []*pluginapi.DeviceSpec
-	devRoot := devManager.GetNodeConfig().GetHostDriverRoot().GetDevRoot()
+	devRoot := devManager.GetNodeConfig().GetHostDevRoot().GetDevRoot()
 	for devPath, optional := range pathOptional {
 		if optional && util.PathIsNotExist(devPath) {
 			continue

--- a/pkg/kubeletplugin/vgpu.go
+++ b/pkg/kubeletplugin/vgpu.go
@@ -179,6 +179,7 @@ func (m *VGPUManager) GetClaimCommonContainerEdits(claim *resourceapi.ResourceCl
 		fmt.Sprintf("%s=", util.CudaSoftCoreLimitEnv),
 		fmt.Sprintf("%s=", util.CudaMemoryLimitEnv),
 		fmt.Sprintf("%s=FALSE", util.CudaMemoryOversoldEnv),
+		fmt.Sprintf("%s=TRUE", util.VMemoryNodeEnabled), // default Enabled
 	}
 	// In NRI mode the partition mounts + register wiring are applied per-container
 	// by the NRI plugin at CreateContainer, not here. Carry the claim UID via CDI

--- a/pkg/util/consts.go
+++ b/pkg/util/consts.go
@@ -181,6 +181,7 @@ const (
 	CudaSoftCoreLimitEnv = "CUDA_CORE_SOFT_LIMIT"
 	// CUDA_CORE_SOFT_LIMIT_<index> gpu memory oversold switch
 	CudaMemoryOversoldEnv = "CUDA_MEM_OVERSOLD"
+	VMemoryNodeEnabled    = "VMEMORY_NODE_ENABLED"
 	// ManagerVisibleDevice Single GPU UUID visible to the container
 	ManagerVisibleDevice = "MANAGER_VISIBLE_DEVICE"
 	// ManagerVisibleDevices List of GPU UUIDs visible to container


### PR DESCRIPTION
1、Stricter GPU memory limitations to prevent over allocation during graphics capture
2、Device plugin CDI supports mounting more additional devices and fixing device path errors
3、Add cuStreamGetCaptureInfo hook to the library and handle abi conflicts
4、Virtual memory node accounting inertia cleaning