### PR TITLE
fix(registry): pids.config 写入加 O_NOFOLLOW，堵住容器可控的符号链接重定向

### DIFF
--- a/pkg/device/registry/server.go
+++ b/pkg/device/registry/server.go
@@ -40,6 +40,7 @@ import (
 //#include <fcntl.h>
 //#include <sys/file.h>
 //#include <time.h>
+//#include <errno.h>
 //
 //int write_to_disk(const char* filename, const char* data) {
 //  int fd = 0;
@@ -50,9 +51,21 @@ import (
 //  int ret = 0;
 //  size_t data_len = 0;
 //  data_len = strlen(data);
-//  fd = open(filename, O_CREAT | O_TRUNC | O_WRONLY, 00777);
+//  // O_NOFOLLOW: this file lives in a directory the WORKLOAD container can
+//  // write (the DRA path bind-mounts <claim>/<partition>/config rw so the
+//  // in-container library can write vgpu.config there). Without it, a container
+//  // that replaces pids.config with a symlink makes this privileged writer
+//  // follow it and truncate whatever it points at -- an arbitrary-write
+//  // primitive over everything in this process's mount namespace, which
+//  // includes the host manager root and the kubelet root. Only the final
+//  // component needs guarding: the parent directories are the bind-mount point
+//  // and above, which the container cannot replace from inside.
+//  fd = open(filename, O_CREAT | O_TRUNC | O_WRONLY | O_NOFOLLOW, 00777);
 //  if (fd == -1) {
-//    return 1;
+//    // ELOOP here means the path existed AND was a symlink. That is not a
+//    // transient error -- nothing legitimate ever creates one -- so report it
+//    // distinctly rather than letting it read as a routine write failure.
+//    return errno == ELOOP ? 3 : 1;
 //  }
 //  while (flock(fd, LOCK_EX)) {
 //    nanosleep(&wait, NULL);
@@ -72,6 +85,12 @@ import "C"
 const (
 	SocketFile = "socket.sock"
 	PidsConfig = "pids.config"
+
+	// writeToDiskSymlinkRefused is the write_to_disk return code for "the target
+	// existed and was a symlink, so O_NOFOLLOW refused the open". Kept distinct
+	// from the generic failure code because it is an attack indicator, not a
+	// transient error. Must match the C function above.
+	writeToDiskSymlinkRefused = 3
 
 	// resolveBackoff is the per-attempt poll interval used while waiting for
 	// the lookup state (informer cache, container status) to become
@@ -501,14 +520,24 @@ func (s *DeviceRegistryServerImpl) persistPids(configDir string, pids []int) err
 		buf.WriteByte('\n')
 	}
 
-	cFileName := C.CString(filepath.Join(configDir, PidsConfig))
+	pidsPath := filepath.Join(configDir, PidsConfig)
+	cFileName := C.CString(pidsPath)
 	cData := C.CString(buf.String())
 	defer func() {
 		C.free(unsafe.Pointer(cFileName))
 		C.free(unsafe.Pointer(cData))
 	}()
-	if C.write_to_disk(cFileName, cData) != 0 {
-		return fmt.Errorf("failed to write pids file at %s", filepath.Join(configDir, PidsConfig))
+	switch rc := C.write_to_disk(cFileName, cData); rc {
+	case 0:
+	case writeToDiskSymlinkRefused:
+		// The container replaced its own pids.config with a symlink. Nothing
+		// legitimate does this, so say so plainly at a level that gets seen --
+		// the open was already refused by O_NOFOLLOW, this is the audit trail.
+		klog.ErrorS(nil, "refused to write pids file: path is a symlink, which no legitimate flow creates; "+
+			"the container may be attempting to redirect this privileged write", "path", pidsPath)
+		return fmt.Errorf("refused to write pids file at %s: path is a symlink", pidsPath)
+	default:
+		return fmt.Errorf("failed to write pids file at %s (code %d)", pidsPath, int(rc))
 	}
 	return nil
 }


### PR DESCRIPTION
DRA 路径把 <claim>/<partition>/config 以 rw 挂进工作负载容器(容器内的库要往那里 写 vgpu.config)，而 registry 服务端的 persistPids 也正是往这个目录写 pids.config，且底层 write_to_disk 的 open() 没有 O_NOFOLLOW。

于是任意一个 vGPU 工作负载可以:
  1. 在 /etc/vgpu-manager/config/pids.config 放一个指向宿主文件的符号链接
  2. 正常地调用 registry 注册 —— 它是给自己注册，四层身份校验(调用方拥有该 Pod、 容器名在 Pod status 中存在且 Running、cgroup 有活进程、SO_PEERCRED 的 PID 在该容器 cgroup 内)全部通过
  3. 特权守护进程 open(O_CREAT|O_TRUNC|O_WRONLY) 跟随链接，把目标文件截断并写入 一串 PID

即守护进程挂载命名空间内的任意文件可被截断改写，其中包含 hostPath 挂进来的
manager root 与 kubelet root。触发条件是 DevicePluginClientMode(alpha，默认关) 配合 DRA 路径。

修复只需给 open() 加 O_NOFOLLOW —— 只需守最后一级路径分量: 父目录是 bind mount 挂载点及其以上，容器在内部无法替换。正常流程中 pids.config 永远是本函数自己以
O_CREAT 创建的普通文件，加了不改变任何已有行为。

同时把 ELOOP 与通用失败区分开(返回码 3)，Go 侧单独打 ErrorS。原因是这两者的性质 完全不同: 写失败是瞬时错误，而这个位置出现符号链接没有任何正当来源，是攻击指示器,
不该混在普通 IO 错误里被忽略。

DP 路径不受影响 —— 它的 config 目录是 ReadOnly 挂载，容器无法植入链接。其余守护 进程侧写入点(vgpu.config 仅 DP 路径写且目录 ro、devices.json 所在目录未挂载、 watcher 与 registry 目录均 ro 挂载)同样不受影响。

背景: 排查 Project-HAMi/HAMi-core#219 时，其 review 意见中的符号链接一条经核对 对本项目成立。该 PR 的功能本身(从环境变量拼容器级缓存路径)不适用 —— 本项目的
per-container 目录本就是这个形态。

注: 环境无 Go 工具链(cgo 需要编译验证)，改动未经编译。