### PR TITLE
fix: dlsym RTLD_NEXT bypassing the vGPU hooks

### DIFF
--- a/docs/sm_core_limit_gap_throttle_design.md
+++ b/docs/sm_core_limit_gap_throttle_design.md
@@ -367,17 +367,15 @@ static void gap_end(int host_index, CUstream stream, CUresult launch_ret) {
 
 ### 7.2 loader.c 的 fork 危害
 
-`child_after_fork()` 还会调用 `loader_child_after_fork()`(定义在 loader.c)处理 4 个 loader 级 mutex 与一个线程键值缓存,它们都有相同的"父持锁瞬间 fork → 子永久 EBUSY"问题:
+`child_after_fork()` 还会调用 `loader_child_after_fork()`(定义在 loader.c)处理 3 个 loader 级 mutex,它们都有相同的"父持锁瞬间 fork → 子永久 EBUSY"问题:
 
 | 资源 | 用途 | 风险等级 |
 |---|---|---|
 | `init_config_mutex` | 保护 `load_controller_configuration` —— **每次 launch hook 入口都会跑到这里**(经 `load_necessary_data`) | **最高**:绝对会触及,父持锁瞬间 fork 必死锁 |
-| `tid_dlsym_lock` | 保护 `tid_dlsyms` 缓存,每次 dlsym 拦截都要拿 | 高:worker 线程频繁触发 |
 | `device_index_mutex` | 保护 `cuda↔nvml↔host` 设备索引查找,被多处调用 | 中:每次需要做索引转换都要拿 |
 | `g_memory_node_lock` | 保护 vmem 节点账本 | 中:仅 vmem 路径触及 |
-| `tid_dlsyms[]` 缓存 | 按 `pthread_t` 键值的 dlsym 递归保护表 | 低:陈旧条目仅是 cache miss,但理论上 `pthread_t` 复用可能假阳性匹配 |
 
-`loader_child_after_fork()` 用 `pthread_mutex_init` 对 4 个 mutex 重新初始化,清空 `tid_dlsyms[]` 数组。被 `pthread_atfork` 通过 cuda_hook.c 的统一入口调用。
+`loader_child_after_fork()` 用 `pthread_mutex_init` 对 3 个 mutex 重新初始化。被 `pthread_atfork` 通过 cuda_hook.c 的统一入口调用。
 
 **注意不重置的 loader.c 内部状态**:
 - `g_cuda_ver_init`/`g_cuda_lib_init`/`g_nvml_lib_init`/`init_nvml_host_index`(loader 的 4 个 `pthread_once_t`):它们守护的是**库加载/版本探测**这类系统级幂等结果,通过 mmap/dlopen 父子共享,跳过等价于"复用已有结果",**正确**。

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/grepplabs/cert-source v0.1.0
 	github.com/julienschmidt/httprouter v1.3.0
-	github.com/opencontainers/cgroups v0.0.7
+	github.com/opencontainers/cgroups v0.1.0
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 	github.com/prometheus/client_golang v1.24.1
 	github.com/sirupsen/logrus v1.9.4
@@ -46,7 +46,7 @@ require (
 	k8s.io/kubernetes v1.37.0-rc.0
 	k8s.io/utils v0.0.0-20260626114624-be93311217bd
 	sigs.k8s.io/controller-runtime v0.24.1
-	sigs.k8s.io/dra-driver-nvidia-gpu v0.4.1
+	sigs.k8s.io/dra-driver-nvidia-gpu v0.5.0
 	tags.cncf.io/container-device-interface v1.1.0
 	tags.cncf.io/container-device-interface/specs-go v1.1.0
 	volcano.sh/apis v1.15.1

--- a/go.sum
+++ b/go.sum
@@ -170,10 +170,10 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/onsi/ginkgo/v2 v2.32.0 h1:Hw7s2pVrQo/8Yz5N77qdnpHaoc+c6cC9WIV1Jce+J6E=
 github.com/onsi/ginkgo/v2 v2.32.0/go.mod h1:+aXOY+vzZ5mu2iI2HpTZUPmM//oQfsNFX6gU9kNcA44=
-github.com/onsi/gomega v1.40.0 h1:Vtol0e1MghCD2ZVIilPDIg44XSL9l2QAn8ZNaljWcJc=
-github.com/onsi/gomega v1.40.0/go.mod h1:M/Uqpu/8qTjtzCLUA2zJHX9Iilrau25x1PdoSRbWh5A=
-github.com/opencontainers/cgroups v0.0.7 h1:FqhggFhigAMgKKwy39jweWX3h7Ha6VBF/qNR6Sso3oc=
-github.com/opencontainers/cgroups v0.0.7/go.mod h1:hPBRvnBhLZueEN0eJyozMeM3HeFGYlZW9KnO//px6G4=
+github.com/onsi/gomega v1.41.0 h1:OwKp4pXNgVxf6sCplzYo794OFNuoL2q2SBMU5NSWOjA=
+github.com/onsi/gomega v1.41.0/go.mod h1:M/Uqpu/8qTjtzCLUA2zJHX9Iilrau25x1PdoSRbWh5A=
+github.com/opencontainers/cgroups v0.1.0 h1:6W05KiDvgj1yi/6D13SJCvYx8TAESz67szvHPxhfcrs=
+github.com/opencontainers/cgroups v0.1.0/go.mod h1:hPBRvnBhLZueEN0eJyozMeM3HeFGYlZW9KnO//px6G4=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/runc v1.4.3 h1:/bq84roxG30xEICkFodXzMEVQFs7kzo4lCiZME1uKxI=
@@ -355,8 +355,8 @@ sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.36.0 h1:/YpDJ4vReG7Zm
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client v0.36.0/go.mod h1:tJo1aepTXyR+8Xs3sUsGBDk4Ub2AM5dPAPKJx0mpm5c=
 sigs.k8s.io/controller-runtime v0.24.1 h1:miPEwrmirImAvgME1L9qebGHrOnGJoVmVdtOU9fRfo4=
 sigs.k8s.io/controller-runtime v0.24.1/go.mod h1:vFkfY5fGt5xAC/sKb8IBFKgWPNKG9OUG29dR8Y2wImw=
-sigs.k8s.io/dra-driver-nvidia-gpu v0.4.1 h1:up4wTyW4UxLDB8I+pDOhQ1+F3Ol2f/qHgN4v6vlcPEc=
-sigs.k8s.io/dra-driver-nvidia-gpu v0.4.1/go.mod h1:9UjEMp43N0Sr7DiCfHiDHYt5gp+dz8NUZA9DQcPJWpM=
+sigs.k8s.io/dra-driver-nvidia-gpu v0.5.0 h1:CjUBJwemlt4kYy5AN+I7Ce4mMp9V4VKR97EBogSoDus=
+sigs.k8s.io/dra-driver-nvidia-gpu v0.5.0/go.mod h1:g3QDHUqyatQNAefd4wkRjzNwFYZ5DJuSIKLfSAogWzE=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 h1:IpInykpT6ceI+QxKBbEflcR5EXP7sU1kvOlxwZh5txg=
 sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730/go.mod h1:mdzfpAEoE6DHQEN0uh9ZbOCuHbLK5wOm7dK4ctXE9Tg=
 sigs.k8s.io/randfill v1.0.0 h1:JfjMILfT8A6RbawdsK2JXGBR5AQVfd+9TbzrlneTyrU=

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -96,6 +96,17 @@ target_link_options(vgpu-control PRIVATE
 set_property(TARGET vgpu-control APPEND PROPERTY
     LINK_DEPENDS ${VGPU_EXPORTS_SCRIPT})
 
+# Our own calls to our own exported symbols bind directly instead of going
+# through the PLT — load_necessary_data() runs on every hook entry, so this
+# is worth the flag. Only affects references made from inside this library;
+# our symbols stay interposable from the outside, which is what the preload
+# mechanism relies on.
+include(CheckCCompilerFlag)
+check_c_compiler_flag(-fno-semantic-interposition VGPU_HAS_NO_SEMANTIC_INTERPOSITION)
+if(VGPU_HAS_NO_SEMANTIC_INTERPOSITION)
+    target_compile_options(vgpu-control PRIVATE -fno-semantic-interposition)
+endif()
+
 # ---------------------------------------------------------------------------
 # Build-time integrity checks for the CUDA hook layer.
 #
@@ -161,6 +172,18 @@ if(VGPU_RUN_HOOK_CHECKS)
         COMMENT "[vgpu] check no constructor/destructor attributes in src/"
         VERBATIM)
     add_dependencies(vgpu-control vgpu_check_no_constructors)
+
+    # Pre-build: forbid public dlsym() calls in library/src/. We export our
+    # own dlsym, so such a call resolves back into the interceptor instead
+    # of libc. Bootstrapping real_dlsym uses dlvsym(), which we do not
+    # export, and stays allowed.
+    add_custom_target(vgpu_check_no_public_dlsym ALL
+        COMMAND bash
+                ${CMAKE_CURRENT_SOURCE_DIR}/hack/check_no_public_dlsym.sh
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        COMMENT "[vgpu] check no public dlsym() calls in src/"
+        VERBATIM)
+    add_dependencies(vgpu-control vgpu_check_no_public_dlsym)
 endif()
 
 # ---------------------------------------------------------------------------

--- a/library/hack/check_no_public_dlsym.sh
+++ b/library/hack/check_no_public_dlsym.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+#
+# Forbid calls to the public dlsym() from library/src/.
+#
+# We export our own dlsym, so a plain dlsym() call inside this library
+# resolves back to that hook rather than to libc. Any such call re-enters
+# the interceptor, and the paths it reaches from there (load_necessary_data
+# -> dlopen under pthread_once) deadlock if re-entered on the same thread.
+# The recursion guard turns that into a failed lookup instead of a hang, but
+# the call still cannot do what it was written to do.
+#
+# Call through the cached real_dlsym pointer instead. Bootstrapping that
+# pointer is the one case with no pointer to call yet, and it uses dlvsym(),
+# which we do not export and which therefore stays allowed here.
+#
+# Run from repo root or library/. Exit non-zero if any bare dlsym() call
+# appears in library/src/.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+SRC_DIR="${1:-${LIB_ROOT}/src}"
+
+if [[ ! -d "${SRC_DIR}" ]]; then
+  echo "[FAIL] library/src not found at ${SRC_DIR}" >&2
+  exit 2
+fi
+
+# Bare `dlsym(` only. A leading identifier character rules out real_dlsym(
+# (the `_` is excluded by the class), and dlvsym( is a different name that
+# this pattern never matches. The definition of our own interceptor is the
+# one line that legitimately reads `dlsym(` and is tagged FUNC_ATTR_VISIBLE.
+matches=$(grep -rnE '(^|[^_[:alnum:]])dlsym[[:space:]]*\(' "${SRC_DIR}" \
+  --include='*.c' --include='*.h' 2>/dev/null \
+  | grep -v 'FUNC_ATTR_VISIBLE' \
+  | grep -vE ':[0-9]+:[[:space:]]*(\*|//|/\*)' \
+  || true)
+
+if [[ -n "${matches}" ]]; then
+  echo "[FAIL] public dlsym() call(s) in ${SRC_DIR}:"
+  echo "${matches}" | sed 's/^/         /'
+  echo
+  echo "       Call real_dlsym(...) instead. Assigning the result to"
+  echo "       real_dlsym does not make it safe -- the call itself is what"
+  echo "       re-enters the interceptor. Use dlvsym() to bootstrap."
+  exit 1
+fi
+
+echo "[PASS] no public dlsym() calls in ${SRC_DIR}"

--- a/library/include/hook.h
+++ b/library/include/hook.h
@@ -644,13 +644,6 @@ typedef struct {
   int external_process_num;
 } utilization_t;
 
-typedef struct {
-  pthread_t tid;
-  void *pointer;
-} tid_dlsym;
-
-#define DLMAP_SIZE 100
-
 typedef enum VGPU_COMPATIBILITY_MODE_enum {
   HOST_COMPATIBILITY_MODE        = 0,
   CGROUPV1_COMPATIBILITY_MODE    = 1,

--- a/library/src/cuda_hook.c
+++ b/library/src/cuda_hook.c
@@ -77,13 +77,12 @@ extern int get_delta_ramp_floor_divisor(int *out);
 extern int get_uva_advise(int *out);
 extern int get_sm_shared_bucket(int *out);
 
-/* fork() child handler implemented in loader.c -- re-inits the three
- * library-internal mutexes (g_memory_node_lock, tid_dlsym_lock,
- * device_index_mutex), resets the driver/nvml-library-load once-guards
- * (g_cuda_ver_init, g_nvml_lib_init, g_cuda_lib_init) so a fork() that
- * lands mid-dlopen cannot leave the child's first hooked call hanging
- * forever, and clears the tid_dlsyms recursion-guard cache. Called from
- * this file's child_after_fork(). */
+/* fork() child handler implemented in loader.c -- re-inits the two
+ * library-internal mutexes (g_memory_node_lock, device_index_mutex),
+ * resets the driver/nvml-library-load once-guards (g_cuda_ver_init,
+ * g_nvml_lib_init, g_cuda_lib_init) so a fork() that lands mid-dlopen
+ * cannot leave the child's first hooked call hanging forever. Called
+ * from this file's child_after_fork(). */
 extern void loader_child_after_fork(void);
 
 static void graph_cost_after_fork(void);
@@ -300,9 +299,8 @@ void child_after_fork(void) {
    * The highest-probability path is the driver/nvml-library-load once-guards
    * (g_cuda_ver_init, g_nvml_lib_init, g_cuda_lib_init), since
    * load_necessary_data() -- which they gate -- runs at every launch hook
-   * entry and does real dlopen/proc-read work; the mutexes (tid_dlsym_lock,
-   * device_index_mutex, g_memory_node_lock) are also hot enough to warrant
-   * the reset. */
+   * entry and does real dlopen/proc-read work; the mutexes (device_index_mutex,
+   * g_memory_node_lock) are also hot enough to warrant the reset. */
   loader_child_after_fork();
 }
 

--- a/library/src/loader.c
+++ b/library/src/loader.c
@@ -1000,7 +1000,6 @@ static void UNUSED bug_on() {
 static pthread_once_t g_cuda_ver_init = PTHREAD_ONCE_INIT;
 static pthread_once_t g_cuda_lib_init = PTHREAD_ONCE_INIT;
 static pthread_once_t g_nvml_lib_init = PTHREAD_ONCE_INIT;
-static pthread_once_t init_dlsym_flag = PTHREAD_ONCE_INIT;
 static pthread_once_t init_nvml_host_index = PTHREAD_ONCE_INIT;
 /* Guards the one-time pthread_atfork(NULL, NULL, child_after_fork) call.
  * Intentionally NOT reset by child_after_fork() in the child -- glibc's
@@ -1095,13 +1094,17 @@ void init_real_dlsym() {
       }
     }
     if (unlikely(!real_dlsym)) {
-      /* Last resort: pull dlsym out of libc.so.6 directly. We deliberately
-       * do NOT fall back to _dl_sym(GLIBC_PRIVATE) -- it was effectively
-       * removed by the glibc 2.34 libdl/libpthread merge and depending on
-       * it breaks library load on modern distributions (Ubuntu 22.04+). */
+      /* Last resort: pull dlsym out of libc.so.6 directly. Must use dlvsym
+       * here -- a plain dlsym() call would resolve back to our own hook.
+       * We deliberately do NOT fall back to _dl_sym(GLIBC_PRIVATE): it was
+       * effectively removed by the glibc 2.34 libdl/libpthread merge and
+       * depending on it breaks library load on modern distributions. */
       void *libc_handle = dlopen("libc.so.6", RTLD_LAZY);
       if (libc_handle) {
-        real_dlsym = dlsym(libc_handle, "dlsym");
+        for (int i = 0; glibc_versions[i] != NULL; i++) {
+          real_dlsym = dlvsym(libc_handle, "dlsym", glibc_versions[i]);
+          if (real_dlsym) break;
+        }
       }
       if (!real_dlsym) {
         LOGGER(FATAL, "unable to find the real dlsym");
@@ -2064,33 +2067,27 @@ DONE:
   return ret;
 }
 
-tid_dlsym tid_dlsyms[DLMAP_SIZE];
-static int tid_dlsym_count = 0;
-static pthread_mutex_t tid_dlsym_lock;
-
-void init_tid_dlsyms(){
-  pthread_mutex_init(&tid_dlsym_lock, NULL);
-  tid_dlsym_count = 0;
-  memset(tid_dlsyms, 0, sizeof(tid_dlsym) * DLMAP_SIZE);
-}
-
-int check_tid_dlsyms(pthread_t tid, void *pointer){
-  int i;
-  int cursor = (tid_dlsym_count < DLMAP_SIZE) ? tid_dlsym_count : DLMAP_SIZE;
-  for (i = cursor - 1; i >= 0; i--) {
-    if ((tid_dlsyms[i].pointer == pointer) && pthread_equal(tid_dlsyms[i].tid, tid)) {
-      return 1;
-    }
-  }
-  cursor = tid_dlsym_count % DLMAP_SIZE;
-  tid_dlsyms[cursor].tid = tid;
-  tid_dlsyms[cursor].pointer = pointer;
-  tid_dlsym_count++;
-  return 0;
-}
-
 extern entry_t nvml_hooks_entry[];
 extern const int nvml_hook_nums;
+
+/* Does `symbol` name a driver entry point we hook? Mirrors the export
+ * patterns in the version script: cu[A-Z]* / cudbg* / nvml[A-Z]*.
+ *
+ * The uppercase discriminator is what keeps cuBLAS, cuFFT, cuDNN,
+ * cudaMalloc and curl_* out -- they share the "cu" prefix but are not
+ * driver API, and matching them costs a symbol lookup plus a misleading
+ * unhooked-symbol note on every resolution. Short strings stop at the
+ * NUL via && short-circuit, so no read runs past the terminator. */
+static inline int symbol_is_cuda_api(const char *s) {
+  if (s[0] != 'c' || s[1] != 'u') return 0;
+  if (s[2] >= 'A' && s[2] <= 'Z') return 1;      /* cu[A-Z]* */
+  return strncmp(s + 2, "dbg", 3) == 0;          /* cudbg*   */
+}
+
+static inline int symbol_is_nvml_api(const char *s) {
+  return s[0] == 'n' && s[1] == 'v' && s[2] == 'm' && s[3] == 'l' &&
+         s[4] >= 'A' && s[4] <= 'Z';             /* nvml[A-Z]* */
+}
 
 /* Resolve our hook for `symbol` from a hijack table.
  *
@@ -2164,6 +2161,20 @@ void note_unhooked_symbol(const char *symbol) {
   /* Probe window exhausted: stay quiet rather than repeat on every lookup. */
 }
 
+/* dlsym(3) interceptor.
+ *
+ * A driver symbol resolves to our hook whatever `handle` says -- RTLD_NEXT
+ * included. RTLD_NEXT normally means "skip the wrapper, give me the real
+ * one", which would be a one-line way out of the vGPU limits, so we do not
+ * honour it for driver symbols. Everything else passes straight through.
+ *
+ * recursion_depth must stay: on a hook hit we call load_necessary_data(),
+ * which dlopen()s the driver under a pthread_once. If a constructor in
+ * that dlopen calls back into dlsym, re-entering the same once on the same
+ * thread deadlocks. The guard short-circuits that nested call instead.
+ * It answers with the real symbol, so a lookup made during our own init is
+ * the one case we do not hook -- the WARNING below is how we would find
+ * out if that ever happens in practice. */
 FUNC_ATTR_VISIBLE void* dlsym(void* handle, const char* symbol) {
   static __thread int recursion_depth = 0;
   if (recursion_depth > 0) {
@@ -2176,18 +2187,7 @@ FUNC_ATTR_VISIBLE void* dlsym(void* handle, const char* symbol) {
   init_real_dlsym();
 
   void* result = NULL;
-  if (handle == RTLD_NEXT) {
-    pthread_once(&init_dlsym_flag, init_tid_dlsyms);
-    result = real_dlsym(RTLD_NEXT, symbol);
-    pthread_mutex_lock(&tid_dlsym_lock);
-    pthread_t tid = pthread_self();
-    if (check_tid_dlsyms(tid, result)) {
-      LOGGER(WARNING, "recursive dlsym: %s",symbol);
-      result = NULL;
-    }
-    pthread_mutex_unlock(&tid_dlsym_lock);
-    goto DONE;
-  } else if (strncmp(symbol, "cu", 2) == 0) { // hijack cuda
+  if (symbol_is_cuda_api(symbol)) {          // hijack cuda
     result = resolve_local_hook(symbol, cuda_hooks_entry, cuda_hook_nums);
     if (likely(result)) {
       LOGGER(DETAIL, "search found cuda hook %s", symbol);
@@ -2195,7 +2195,7 @@ FUNC_ATTR_VISIBLE void* dlsym(void* handle, const char* symbol) {
       goto DONE;
     }
     note_unhooked_symbol(symbol);
-  } else if (strncmp(symbol, "nvml", 4) == 0) { // hijack nvml
+  } else if (symbol_is_nvml_api(symbol)) {   // hijack nvml
     result = resolve_local_hook(symbol, nvml_hooks_entry, nvml_hook_nums);
     if (likely(result)) {
       LOGGER(DETAIL, "search found nvml hook %s", symbol);
@@ -2971,7 +2971,7 @@ void init_nvml_to_host_device_index() {
  * every later pthread_mutex_lock/pthread_once in the child then hangs
  * forever.
  *
- * Mutexes reset: g_memory_node_lock, tid_dlsym_lock, device_index_mutex.
+ * Mutexes reset: g_memory_node_lock, device_index_mutex.
  *
  * Once-guards reset: g_cuda_ver_init, g_nvml_lib_init, g_cuda_lib_init --
  * gate driver-version/library loading inside load_necessary_data(), which
@@ -2983,14 +2983,9 @@ void init_nvml_to_host_device_index() {
  * anything sees it. Also reset: init_nvml_host_index,
  * g_controller_config_init, g_reset_cuda_index_init.
  *
- * Deliberately NOT reset: init_dlsym_flag and g_atfork_init. Their targets
- * are already redone directly a few lines below (or, for g_atfork_init,
- * survive fork via glibc's own atfork list) -- resetting them too would
- * just make the child redo already-valid setup, risking a reinit-while-live
- * mutex instead of a harmless no-op.
- *
- * tid_dlsyms[] is cleared because parent pthread_t values are stale in the
- * child; a stale entry just misses and falls through to a real dlsym. */
+ * Deliberately NOT reset: g_atfork_init. It survives fork via glibc's own
+ * atfork list, so re-registering it in the child would just accumulate a
+ * duplicate atfork handler per fork generation. */
 void loader_child_after_fork(void) {
   // After forking, it is necessary to use it to trigger nvmlInit again to ensure that
   // subsequent steps that require nvml will not fail due to lack of initialization.
@@ -3001,10 +2996,7 @@ void loader_child_after_fork(void) {
   g_controller_config_init = (pthread_once_t)PTHREAD_ONCE_INIT;
   g_reset_cuda_index_init = (pthread_once_t)PTHREAD_ONCE_INIT;
   pthread_mutex_init(&g_memory_node_lock, NULL);
-  pthread_mutex_init(&tid_dlsym_lock,     NULL);
   pthread_mutex_init(&device_index_mutex, NULL);
-  memset(tid_dlsyms, 0, sizeof(tid_dlsyms));
-  tid_dlsym_count = 0;
 
   /* Drop the inherited virtual-memory records -- they describe the PARENT's
    * allocations, and CUDA contexts don't survive fork. Keeping them is

--- a/library/test/test_dlsym_rtld_next.c
+++ b/library/test/test_dlsym_rtld_next.c
@@ -1,0 +1,79 @@
+/*
+ * dlsym(RTLD_NEXT, ...): repeated lookups, and driver symbols.
+ *
+ * Two properties of the RTLD_NEXT path are worth pinning:
+ *
+ *   - A non-driver symbol passes through, and resolving it twice from the
+ *     same thread returns the same non-NULL pointer both times. An earlier
+ *     implementation kept a per-thread history of resolved pointers and
+ *     answered NULL on the second sighting, reading ordinary repetition as
+ *     recursion.
+ *
+ *   - A driver symbol resolves to OUR hook, not to the driver. RTLD_NEXT
+ *     normally asks to skip the wrapper, which would otherwise be a way
+ *     around the vGPU limits, so the loader ignores it for cu.../nvml...
+ *
+ * No GPU needed: dladdr answers the ownership question without calling
+ * anything.
+ *
+ * Run:
+ *   LD_PRELOAD=<build>/libvgpu-control.so ./test_dlsym_rtld_next
+ */
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "test_utils.h"  /* VGPU_REQUIRE_PRELOAD */
+
+/* Is `p` a function inside libvgpu-control.so? */
+static int owned_by_us(void *p) {
+  Dl_info info;
+  if (!dladdr(p, &info) || info.dli_fname == NULL) return 0;
+  return strstr(info.dli_fname, "libvgpu-control") != NULL;
+}
+
+int main(void) {
+  VGPU_REQUIRE_PRELOAD();
+
+  int failures = 0;
+
+  printf("[A] a non-driver symbol resolves through RTLD_NEXT\n");
+  void *p1 = dlsym(RTLD_NEXT, "open");
+  if (!p1) {
+    printf("  FAIL: first call returned NULL\n");
+    failures++;
+  }
+
+  printf("[B] resolving it again returns the same pointer, not NULL\n");
+  void *p2 = dlsym(RTLD_NEXT, "open");
+  if (!p2) {
+    printf("  FAIL: second call returned NULL\n");
+    failures++;
+  } else if (p1 && p2 != p1) {
+    printf("  FAIL: second call returned %p, first returned %p\n", p2, p1);
+    failures++;
+  }
+
+  printf("[C] a driver symbol resolves to our hook, not the driver\n");
+  void *hook = dlsym(RTLD_NEXT, "cuMemAlloc");
+  if (!hook) {
+    printf("  FAIL: cuMemAlloc did not resolve\n");
+    failures++;
+  } else if (!owned_by_us(hook)) {
+    Dl_info info;
+    printf("  FAIL: cuMemAlloc resolved outside our library (%s) -- the "
+           "limits can be bypassed this way\n",
+           dladdr(hook, &info) && info.dli_fname ? info.dli_fname : "?");
+    failures++;
+  }
+
+  printf("[D] a non-driver symbol is NOT claimed by us\n");
+  if (p1 && owned_by_us(p1)) {
+    printf("  FAIL: \"open\" resolved into our library\n");
+    failures++;
+  }
+
+  printf("\nResult: %s\n", failures ? "FAIL" : "PASS");
+  return failures ? 1 : 0;
+}

--- a/pkg/device/manager/health.go
+++ b/pkg/device/manager/health.go
@@ -295,7 +295,7 @@ func getDisabledHealthCheckXids() disabledXIDs {
 
 	// Add the list of hardcoded disabled (ignored) XIDs:
 	// FIXME: formalize the full list and document it.
-	// http://docs.nvidia.com/deploy/xid-errors/index.html#topic_4
+	// https://docs.nvidia.com/deploy/xid-errors/latest/analyzing-xid-catalog.html
 	// Application errors: the GPU should still be healthy
 	ignoredXids := []uint64{
 		13,  // Graphics Engine Exception

--- a/pkg/device/nvidia/nvlib.go
+++ b/pkg/device/nvidia/nvlib.go
@@ -36,7 +36,8 @@ import (
 type CudaDriverVersion int
 
 func (v CudaDriverVersion) String() string {
-	return fmt.Sprintf("%d", v)
+	major, minor := v.MajorAndMinor()
+	return fmt.Sprintf("%d.%d", major, minor)
 }
 
 func (v CudaDriverVersion) MajorAndMinor() (major uint, minor uint) {

--- a/pkg/deviceplugin/vgpu/vnum_plugin.go
+++ b/pkg/deviceplugin/vgpu/vnum_plugin.go
@@ -207,7 +207,8 @@ func (m *vNumberDevicePlugin) registryDevices(featureGate featuregate.FeatureGat
 		return nil, err
 	}
 	driverVersion := m.baseServer.GetDeviceManager().GetDriverVersion().DriverVersion
-	cudaDriverVersion := strconv.Itoa(int(m.baseServer.GetDeviceManager().GetDriverVersion().CudaDriverVersion))
+	cudaDriverVersion := m.baseServer.GetDeviceManager().GetDriverVersion().CudaDriverVersion.String()
+	major, minor := m.baseServer.GetDeviceManager().GetDriverVersion().CudaDriverVersion.MajorAndMinor()
 	metadata := client.PatchMetadata{
 		Annotations: map[string]*string{
 			util.NodeConfigInfoAnnotation:     pointer.String(nodeConfigEncode),
@@ -217,6 +218,8 @@ func (m *vNumberDevicePlugin) registryDevices(featureGate featuregate.FeatureGat
 		Labels: map[string]*string{
 			util.NodeNvidiaDriverVersionLabel: pointer.String(driverVersion),
 			util.NodeNvidiaCudaVersionLabel:   pointer.String(cudaDriverVersion),
+			util.NodeNvidiaCudaMajorLabel:     pointer.String(strconv.Itoa(int(major))),
+			util.NodeNvidiaCudaMinorLabel:     pointer.String(strconv.Itoa(int(minor))),
 		},
 	}
 	return &metadata, nil
@@ -234,6 +237,8 @@ func (m *vNumberDevicePlugin) cleanupRegistry(_ featuregate.FeatureGate) (*clien
 		Labels: map[string]*string{
 			util.NodeNvidiaDriverVersionLabel: nil,
 			util.NodeNvidiaCudaVersionLabel:   nil,
+			util.NodeNvidiaCudaMajorLabel:     nil,
+			util.NodeNvidiaCudaMinorLabel:     nil,
 		},
 	}
 	return &metadata, nil

--- a/pkg/kubeletplugin/allocatable.go
+++ b/pkg/kubeletplugin/allocatable.go
@@ -105,25 +105,26 @@ func (d *AllocatableDevice) CanonicalName() string {
 }
 
 func (d *AllocatableDevice) GetDevice(config *Config) resourceapi.Device {
+	var dev resourceapi.Device
 	switch d.Type() {
 	case GpuDeviceType:
-		dev := d.Gpu.GetDevice()
+		dev = d.Gpu.GetDevice()
 		applyConsumableShares(&dev, config)
-		return dev
 	case MigStaticDeviceType:
-		dev := d.MigStatic.GetDevice()
+		dev = d.MigStatic.GetDevice()
 		applyConsumableShares(&dev, config)
-		return dev
 	case MigDynamicDeviceType:
 		panic("GetDevice() must currently not be called for MigDynamicDeviceType")
 	case VfioDeviceType:
 		// VFIO passthrough devices do not support consumable shares.
-		return d.Vfio.GetDevice()
+		dev = d.Vfio.GetDevice()
 	case VGpuDeviceType:
-		return d.VGpu.GetDevice()
+		dev = d.VGpu.GetDevice()
 	default:
 		panic("unexpected type for AllocatableDevice")
 	}
+	dev.Taints = d.Taints()
+	return dev
 }
 
 // UUID() is here for `AllocatableDevices` to implement the `UUIDProvider`
@@ -402,4 +403,72 @@ func (d *AllocatableDevice) AddOrUpdateTaint(taint *resourceapi.DeviceTaint) boo
 	// 3. Key doesn't exist yet, append the dereferenced struct
 	d.taints = append(d.taints, *taint)
 	return true
+}
+
+// RemoveTaint removes the taint with the specified key. It returns true when a
+// taint was removed.
+func (d *AllocatableDevice) RemoveTaint(key string) (resourceapi.DeviceTaint, bool) {
+	for i, taint := range d.taints {
+		if taint.Key == key {
+			d.taints = slices.Delete(d.taints, i, i+1)
+			return taint, true
+		}
+	}
+	return resourceapi.DeviceTaint{}, false
+}
+
+func (d AllocatableDevices) GetGPUDeviceByUUID(uuid string) *AllocatableDevice {
+	for _, device := range d {
+		if device.Type() == GpuDeviceType &&
+			device.Gpu.UUID == uuid {
+			return device
+		}
+	}
+
+	return nil
+}
+
+func (d AllocatableDevices) GetMigStaticDeviceByLiveTuple(tuple *MigLiveTuple) *AllocatableDevice {
+	if tuple == nil {
+		return nil
+	}
+	for _, device := range d {
+		if device.Type() != MigStaticDeviceType {
+			continue
+		}
+		migTuple := device.MigStatic.LiveTuple()
+		if migTuple.ParentUUID == tuple.ParentUUID &&
+			migTuple.GIID == tuple.GIID &&
+			migTuple.CIID == tuple.CIID {
+			return device
+		}
+	}
+
+	return nil
+}
+
+func (d AllocatableDevices) GetMigDynamicDeviceByTuple(tuple *MigSpecTuple) *AllocatableDevice {
+	if tuple == nil {
+		return nil
+	}
+	for _, device := range d {
+		if device.Type() != MigDynamicDeviceType {
+			continue
+		}
+		migTuple := device.MigDynamic.Tuple()
+		if migTuple.ParentPCIBusID == tuple.ParentPCIBusID &&
+			migTuple.ProfileID == tuple.ProfileID &&
+			migTuple.PlacementStart == tuple.PlacementStart {
+			return device
+		}
+	}
+	return nil
+}
+
+func (d AllocatableDevices) List() []*AllocatableDevice {
+	deviceList := make([]*AllocatableDevice, 0, len(d))
+	for _, device := range d {
+		deviceList = append(deviceList, device)
+	}
+	return deviceList
 }

--- a/pkg/kubeletplugin/device_health.go
+++ b/pkg/kubeletplugin/device_health.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
+	"github.com/coldzerofear/vgpu-manager/pkg/kubeletplugin/featuregates"
 	"github.com/coldzerofear/vgpu-manager/pkg/util"
 	resourceapi "k8s.io/api/resource/v1"
 	"k8s.io/klog/v2"
@@ -103,15 +104,12 @@ func healthEventToTaint(monitor deviceHealthMonitor, event *DeviceHealthEvent) *
 	}
 }
 
-// For a MIG device the placement is defined by the 3-tuple <parent UUID, GI, CI>.
-// For a full device the returned 3-tuple is the device's uuid and (FullGPUInstanceID) 0xFFFFFFFF for the other two elements.
-type devicePlacementMap map[string]map[uint32]map[uint32]*AllocatableDevice
-
 type nvmlDeviceHealthMonitor struct {
 	nvmllib           nvml.Interface
 	eventSet          nvml.EventSet
 	unhealthy         chan *DeviceHealthEvent
-	deviceByPlacement devicePlacementMap
+	perGPUAllocatable *PerGPUAllocatableDevices
+	gpuInfosByUUID    map[string]*GpuDeviceInfo
 	skippedXids       map[uint64]bool
 	wg                sync.WaitGroup
 }
@@ -134,13 +132,16 @@ func newNvmlDeviceHealthMonitor(config *Config, perGPUAllocatable *PerGPUAllocat
 	m := &nvmlDeviceHealthMonitor{
 		nvmllib:           nvdevlib,
 		unhealthy:         make(chan *DeviceHealthEvent, len(all)),
-		deviceByPlacement: getDevicePlacementMap(all),
+		perGPUAllocatable: perGPUAllocatable,
+		gpuInfosByUUID:    nvdevlib.gpuInfosByUUID,
 		skippedXids:       xidsToSkip(config.Flags.AdditionalXidsToIgnore),
 	}
 	return m, nil
 }
 
-func (m *nvmlDeviceHealthMonitor) Start(ctx context.Context) (rerr error) {
+// RegisterEvents creates the NVML event set and starts recording events for
+// every physical parent GPU before the kubelet server accepts requests.
+func (m *nvmlDeviceHealthMonitor) RegisterEvents() (rerr error) {
 	if ret := m.nvmllib.Init(); ret != nvml.SUCCESS {
 		return fmt.Errorf("failed to initialize NVML: %w", ret)
 	}
@@ -161,7 +162,14 @@ func (m *nvmlDeviceHealthMonitor) Start(ctx context.Context) (rerr error) {
 
 	klog.V(4).Info("registering NVML events for device health monitor")
 	m.registerEventsForDevices()
+	return nil
+}
 
+// Start launches the NVML event wait loop after RegisterEvents has completed.
+func (m *nvmlDeviceHealthMonitor) Start(ctx context.Context) error {
+	if m.eventSet == nil {
+		return fmt.Errorf("NVML events have not been registered")
+	}
 	m.wg.Go(func() {
 		m.run(ctx)
 	})
@@ -173,28 +181,28 @@ func (m *nvmlDeviceHealthMonitor) Start(ctx context.Context) (rerr error) {
 func (m *nvmlDeviceHealthMonitor) registerEventsForDevices() {
 	eventMask := uint64(nvml.EventTypeXidCriticalError | nvml.EventTypeDoubleBitEccError | nvml.EventTypeSingleBitEccError)
 
-	for parentUUID, giMap := range m.deviceByPlacement {
-		gpu, ret := m.nvmllib.DeviceGetHandleByUUID(parentUUID)
+	for pciBusID, devices := range m.perGPUAllocatable.allocatablesMap {
+		gpu, ret := m.nvmllib.DeviceGetHandleByPciBusId(string(pciBusID))
 		if ret != nvml.SUCCESS {
-			klog.Warningf("Unable to get device handle from UUID[%s]: %v; marking it as unhealthy", parentUUID, ret)
-			m.sendHealthEventForDevices(giMap, HealthEventUnmonitored)
+			klog.Warningf("Unable to get device handle from PCI Bus ID[%s]: %v; marking devices as unmonitored", pciBusID, ret)
+			m.sendHealthEventForDevices(devices, HealthEventUnmonitored)
 			continue
 		}
 
 		supportedEvents, ret := gpu.GetSupportedEventTypes()
 		if ret != nvml.SUCCESS {
-			klog.Warningf("unable to determine the supported events for %s: %v; marking it as unhealthy", parentUUID, ret)
-			m.sendHealthEventForDevices(giMap, HealthEventUnmonitored)
+			klog.Warningf("unable to determine the supported events for %s: %v; marking devices as unmonitored", pciBusID, ret)
+			m.sendHealthEventForDevices(devices, HealthEventUnmonitored)
 			continue
 		}
 
 		ret = gpu.RegisterEvents(eventMask&supportedEvents, m.eventSet)
 		if ret == nvml.ERROR_NOT_SUPPORTED {
-			klog.Warningf("Device %v is too old to support healthchecking.", parentUUID)
-			m.sendHealthEventForDevices(giMap, HealthEventUnmonitored)
+			klog.Warningf("Device %v is too old to support healthchecking.", pciBusID)
+			m.sendHealthEventForDevices(devices, HealthEventUnmonitored)
 		} else if ret != nvml.SUCCESS {
-			klog.Warningf("unable to register events for %s: %v; marking it as unhealthy", parentUUID, ret)
-			m.sendHealthEventForDevices(giMap, HealthEventUnmonitored)
+			klog.Warningf("unable to register events for %s: %v; marking devices as unmonitored", pciBusID, ret)
+			m.sendHealthEventForDevices(devices, HealthEventUnmonitored)
 		}
 	}
 }
@@ -270,13 +278,19 @@ func (m *nvmlDeviceHealthMonitor) run(ctx context.Context) {
 				m.sendHealthEventForAllDevices(HealthEventGPULost)
 				continue
 			}
-			affectedDevice := m.deviceByPlacement.get(eventUUID, gi, ci)
+			affectedDevice, err := m.resolveDeviceByEventAddress(eventUUID, event.Device, gi, ci)
+			// An error indicates inconsistent UUID/PCI inventory. A nil device
+			// without an error means the event's GI/CI is not available.
+			if err != nil {
+				klog.Warningf("Unable to resolve XID=%d event for UUID:%s, GI:%d, CI:%d: %v", xid, eventUUID, gi, ci, err)
+				continue
+			}
 			if affectedDevice == nil {
 				klog.V(6).Infof("Ignoring event for unexpected device (UUID:%s, GI:%d, CI:%d)", eventUUID, gi, ci)
 				continue
 			}
 
-			klog.V(4).Infof("Sending XID=%d health event for device %s", xid, affectedDevice.UUID())
+			klog.V(4).Infof("Sending XID=%d health event for device %s", xid, affectedDevice.CanonicalName())
 			m.unhealthy <- &DeviceHealthEvent{
 				Devices:   []*AllocatableDevice{affectedDevice},
 				EventType: HealthEventXID,
@@ -294,28 +308,90 @@ func (m *nvmlDeviceHealthMonitor) Unhealthy() <-chan *DeviceHealthEvent {
 // single batched DeviceHealthEvent so the consumer makes one ResourceSlice
 // update.
 func (m *nvmlDeviceHealthMonitor) sendHealthEventForAllDevices(eventType DeviceHealthEventType) {
-	var devices []*AllocatableDevice
-	for _, giMap := range m.deviceByPlacement {
-		devices = append(devices, flattenMIGDeviceMap(giMap)...)
-	}
-	m.sendBatchedHealthEvent(devices, eventType)
+	m.sendBatchedHealthEvent(m.perGPUAllocatable.GetAllDevices().List(), eventType)
 }
 
 // sendHealthEventForDevices aggregates all devices under a single parent GPU
 // into one batched DeviceHealthEvent.
-func (m *nvmlDeviceHealthMonitor) sendHealthEventForDevices(giMap map[uint32]map[uint32]*AllocatableDevice, eventType DeviceHealthEventType) {
-	m.sendBatchedHealthEvent(flattenMIGDeviceMap(giMap), eventType)
+func (m *nvmlDeviceHealthMonitor) sendHealthEventForDevices(devices AllocatableDevices, eventType DeviceHealthEventType) {
+	m.sendBatchedHealthEvent(devices.List(), eventType)
 }
 
-// flattenMIGDeviceMap flattens a GI→CI device map into a slice.
-func flattenMIGDeviceMap(giMap map[uint32]map[uint32]*AllocatableDevice) []*AllocatableDevice {
-	var devices []*AllocatableDevice
-	for _, ciMap := range giMap {
-		for _, dev := range ciMap {
-			devices = append(devices, dev)
-		}
+// NVML identifies a MIG-scoped event by the tuple (parent UUID, GPU instance
+// ID, compute instance ID). A full-GPU event reports FullGPUInstanceID for both
+// the GPU instance ID and compute instance ID.
+//
+// resolveDeviceByEventAddress maps this address, extracted from an NVML event,
+// to an advertised allocatable device.
+func (m *nvmlDeviceHealthMonitor) resolveDeviceByEventAddress(parentUUID string, eventDevice nvml.Device, gi, ci uint32) (*AllocatableDevice, error) {
+	parent, ok := m.gpuInfosByUUID[parentUUID]
+	if !ok {
+		return nil, fmt.Errorf("failed to find parent GPU UUID %s in the discovered GPU inventory", parentUUID)
 	}
-	return devices
+	devices, ok := m.perGPUAllocatable.allocatablesMap[parent.PciBusID]
+	if !ok {
+		return nil, fmt.Errorf("failed to find PCI Bus ID %s for parent GPU UUID %s in the allocatable inventory", parent.PciBusID, parent.UUID)
+	}
+
+	switch {
+	case gi == FullGPUInstanceID && ci == FullGPUInstanceID:
+		return devices.GetGPUDeviceByUUID(parentUUID), nil
+
+	case gi != FullGPUInstanceID && ci != FullGPUInstanceID:
+		if featuregates.Enabled(featuregates.DynamicMIG) {
+			spec, err := resolveMigEvent(eventDevice, parent, gi, ci)
+			if err != nil {
+				return nil, fmt.Errorf("failed to resolve Dynamic MIG device for parent %s, GI=%d, CI=%d: %w", parentUUID, gi, ci, err)
+			}
+			return devices.GetMigDynamicDeviceByTuple(spec), nil
+		}
+		return devices.GetMigStaticDeviceByLiveTuple(&MigLiveTuple{
+			ParentUUID: parentUUID,
+			GIID:       int(gi),
+			CIID:       int(ci),
+		}), nil
+
+	default:
+		// A GI can exist without a CI, but it does not represent a usable,
+		// allocatable MIG device. Similar to device plugin, treat an event
+		// as MIG-scoped only when both GI and CI are present.
+		//
+		// See:
+		// https://github.com/NVIDIA/k8s-device-plugin/blob/main/internal/rm/health.go#L160
+		// https://docs.nvidia.com/deploy/nvml-api/structnvmlEventData__t.html
+		// https://docs.nvidia.com/datacenter/tesla/mig-user-guide/latest/getting-started-with-mig.html#creating-gpu-instances
+		klog.V(6).Infof("Ignoring NVML event with inconsistent instance address for parent UUID %s: GI=%d, CI=%d", parentUUID, gi, ci)
+		return nil, nil
+	}
+}
+
+// resolveMigEvent translates the live GI/CI address reported by NVML into the
+// abstract profile and placement used to advertise a Dynamic MIG device.
+func resolveMigEvent(device nvml.Device, parent *GpuDeviceInfo, giID, ciID uint32) (*MigSpecTuple, error) {
+	gi, ret := device.GetGpuInstanceById(int(giID))
+	if ret != nvml.SUCCESS {
+		return nil, fmt.Errorf("failed to get GPU instance %d: %w", giID, ret)
+	}
+	giInfo, ret := gi.GetInfo()
+	if ret != nvml.SUCCESS {
+		return nil, fmt.Errorf("failed to get info for GPU instance %d: %w", giID, ret)
+	}
+
+	_, ret = gi.GetComputeInstanceById(int(ciID))
+	if ret != nvml.SUCCESS {
+		return nil, fmt.Errorf("failed to get compute instance %d in GPU instance %d: %w", ciID, giID, ret)
+	}
+
+	klog.V(6).Infof(
+		"Resolved Dynamic MIG event (UUID:%s, GI:%d, CI:%d) to profile ID %d, placement start %d",
+		parent.UUID, giID, ciID, giInfo.ProfileId, giInfo.Placement.Start,
+	)
+	return &MigSpecTuple{
+		ParentMinor:    parent.Minor,
+		ParentPCIBusID: parent.PciBusID,
+		ProfileID:      int(giInfo.ProfileId),
+		PlacementStart: int(giInfo.Placement.Start),
+	}, nil
 }
 
 // sendBatchedHealthEvent sends a single DeviceHealthEvent containing all
@@ -335,71 +411,6 @@ func (m *nvmlDeviceHealthMonitor) sendBatchedHealthEvent(devices []*AllocatableD
 	default:
 		klog.Errorf("Health event channel full; dropping batched %s event for %d device(s)", eventType, len(devices))
 	}
-}
-
-// The purpose of this function is to allow for a O(1) lookup of
-// AllocatableDevice by ([parent]UUID, GI, CI) when processing health events. It
-// currently assumes that this is constant for the lifetime of the healthchecker
-// which does not hold for Dynamic MIG. This will have to be resolved once we
-// support device health checking with dynamic MIG.
-func getDevicePlacementMap(allocatable AllocatableDevices) devicePlacementMap {
-	placementMap := make(devicePlacementMap)
-
-	for _, d := range allocatable {
-		var parentUUID string
-		var giID, ciID uint32
-
-		switch d.Type() {
-		case GpuDeviceType, VGpuDeviceType:
-			parentUUID = d.UUID()
-			if parentUUID == "" {
-				continue
-			}
-			giID = FullGPUInstanceID
-			ciID = FullGPUInstanceID
-
-		case MigStaticDeviceType:
-			parentUUID = d.MigStatic.Parent.UUID
-
-			// Note(JP): it's unclear why we handle this case here (and why do
-			// we think this can be empty?)
-			if parentUUID == "" {
-				continue
-			}
-			giID = d.MigStatic.GiInfo.Id
-			ciID = d.MigStatic.CiInfo.Id
-
-		default:
-			// This may be a problem; and should be logged
-			klog.V(4).Infof("getDevicePlacementMap: skipping device with type: %s", d.Type())
-			continue
-		}
-		placementMap.addDevice(parentUUID, giID, ciID, d)
-	}
-	return placementMap
-}
-
-func (p devicePlacementMap) addDevice(parentUUID string, giID uint32, ciID uint32, d *AllocatableDevice) {
-	if _, ok := p[parentUUID]; !ok {
-		p[parentUUID] = make(map[uint32]map[uint32]*AllocatableDevice)
-	}
-	if _, ok := p[parentUUID][giID]; !ok {
-		p[parentUUID][giID] = make(map[uint32]*AllocatableDevice)
-	}
-	p[parentUUID][giID][ciID] = d
-}
-
-func (p devicePlacementMap) get(uuid string, gi, ci uint32) *AllocatableDevice {
-	giMap, ok := p[uuid]
-	if !ok {
-		return nil
-	}
-
-	ciMap, ok := giMap[gi]
-	if !ok {
-		return nil
-	}
-	return ciMap[ci]
 }
 
 // getAdditionalXids returns a list of additional Xids to skip from the specified string.
@@ -431,8 +442,9 @@ func getAdditionalXids(input string) []uint64 {
 
 func xidsToSkip(additionalXids string) map[uint64]bool {
 	// Add the list of hardcoded disabled (ignored) XIDs:
-	// http://docs.nvidia.com/deploy/xid-errors/index.html#topic_4
+	// https://docs.nvidia.com/deploy/xid-errors/latest/analyzing-xid-catalog.html
 	// Application errors: the GPU should still be healthy.
+	// If you change this list, update the documentation.
 	ignoredXids := []uint64{
 		13,  // Graphics Engine Exception
 		31,  // GPU memory page fault

--- a/pkg/kubeletplugin/device_health_test.go
+++ b/pkg/kubeletplugin/device_health_test.go
@@ -20,6 +20,9 @@ import (
 	"context"
 	"testing"
 
+	nvdev "github.com/NVIDIA/go-nvlib/pkg/nvlib/device"
+	"github.com/NVIDIA/go-nvml/pkg/nvml"
+	"github.com/coldzerofear/vgpu-manager/pkg/device/nvidia"
 	resourceapi "k8s.io/api/resource/v1"
 
 	"github.com/stretchr/testify/assert"
@@ -142,6 +145,36 @@ func TestAddOrUpdateTaint_TimeAddedResetOnChange(t *testing.T) {
 	})
 
 	assert.Nil(t, dev.Taints()[0].TimeAdded, "TimeAdded should be nil so the API server sets a fresh timestamp")
+}
+
+func TestPartGetDeviceIncludesHealthTaints(t *testing.T) {
+	parent := &GpuDeviceInfo{
+		GpuInfo: &nvidia.GpuInfo{
+			UUID:                  "GPU-parent-1",
+			Minor:                 0,
+			CudaComputeCapability: "9.0",
+			DriverVersion: nvidia.DriverVersion{
+				DriverVersion:     "580.0.0",
+				CudaDriverVersion: 13000,
+			},
+		},
+	}
+	dev := &AllocatableDevice{MigDynamic: &MigSpec{
+		Parent:        parent,
+		Profile:       &nvdev.MigProfileInfo{G: 1, GB: 5, GIProfileID: 19},
+		GIProfileInfo: nvml.GpuInstanceProfileInfo{Id: 19},
+		Placement:     nvml.GpuInstancePlacement{Start: 0, Size: 1},
+	}}
+	taint := &resourceapi.DeviceTaint{
+		Key:    TaintKeyXID,
+		Value:  "43",
+		Effect: resourceapi.DeviceTaintEffectNone,
+	}
+	require.True(t, dev.AddOrUpdateTaint(taint))
+
+	got := dev.PartGetDevice(nil)
+	require.Len(t, got.Taints, 1)
+	assert.Equal(t, *taint, got.Taints[0])
 }
 
 func TestHealthEventToTaint(t *testing.T) {
@@ -283,4 +316,185 @@ func TestIsEventNonFatal(t *testing.T) {
 			assert.Equal(t, tc.expected, m.IsEventNonFatal(tc.event))
 		})
 	}
+}
+
+func TestAllocatableDevicesFindByAddress(t *testing.T) {
+	parent := &GpuDeviceInfo{GpuInfo: &nvidia.GpuInfo{UUID: "GPU-parent-1", Minor: 0, PciBusID: "0000:01:00.0"}}
+	fullGPU := &AllocatableDevice{Gpu: parent}
+	staticMIG := &AllocatableDevice{
+		MigStatic: &MigDeviceInfo{
+			MigInfo: &nvidia.MigInfo{
+				Parent: parent.GpuInfo,
+			},
+			ParentUUID: parent.UUID,
+			GIID:       2,
+			CIID:       3,
+		},
+	}
+	devices := AllocatableDevices{
+		"gpu":    fullGPU,
+		"static": staticMIG,
+	}
+
+	assert.Equal(t, fullGPU, devices.GetGPUDeviceByUUID(parent.UUID))
+	assert.Nil(t, devices.GetGPUDeviceByUUID("GPU-unknown"))
+	assert.Equal(t, staticMIG, devices.GetMigStaticDeviceByLiveTuple(&MigLiveTuple{
+		ParentUUID: parent.UUID,
+		GIID:       2,
+		CIID:       3,
+	}))
+	assert.Nil(t, devices.GetMigStaticDeviceByLiveTuple(&MigLiveTuple{
+		ParentUUID: parent.UUID,
+		GIID:       2,
+		CIID:       4,
+	}))
+	assert.Nil(t, devices.GetMigStaticDeviceByLiveTuple(&MigLiveTuple{
+		ParentUUID: "GPU-unknown",
+		GIID:       2,
+		CIID:       3,
+	}))
+	assert.Nil(t, devices.GetMigStaticDeviceByLiveTuple(nil))
+}
+
+func TestAllocatableDevicesFindDynamicMIGBySpec(t *testing.T) {
+	parent := &GpuDeviceInfo{GpuInfo: &nvidia.GpuInfo{UUID: "GPU-parent-1", Minor: 0, PciBusID: "0000:01:00.0"}}
+	dynamicMIG := &AllocatableDevice{MigDynamic: &MigSpec{
+		Parent:        parent,
+		GIProfileInfo: nvml.GpuInstanceProfileInfo{Id: 19},
+		Placement:     nvml.GpuInstancePlacement{Start: 0},
+	}}
+	devices := AllocatableDevices{"dynamic": dynamicMIG}
+
+	tests := []struct {
+		name string
+		spec *MigSpecTuple
+		want *AllocatableDevice
+	}{
+		{name: "exact match", spec: &MigSpecTuple{ParentPCIBusID: parent.PciBusID, ProfileID: 19, PlacementStart: 0}, want: dynamicMIG},
+		{name: "profile mismatch", spec: &MigSpecTuple{ParentPCIBusID: parent.PciBusID, ProfileID: 14, PlacementStart: 0}},
+		{name: "placement mismatch", spec: &MigSpecTuple{ParentPCIBusID: parent.PciBusID, ProfileID: 19, PlacementStart: 1}},
+		{name: "parent mismatch", spec: &MigSpecTuple{ParentPCIBusID: "0000:02:00.0", ProfileID: 19, PlacementStart: 0}},
+		{name: "nil spec"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, devices.GetMigDynamicDeviceByTuple(tc.spec))
+		})
+	}
+}
+
+func TestResolveDeviceByEventAddressUsesGPUUUIDIndex(t *testing.T) {
+	parent := &nvidia.GpuInfo{UUID: "GPU-parent-1", Minor: 0, PciBusID: "0000:01:00.0"}
+	staticMIG := &AllocatableDevice{
+		MigStatic: &MigDeviceInfo{
+			MigInfo: &nvidia.MigInfo{
+				Parent: parent,
+			},
+			ParentUUID: parent.UUID,
+			GIID:       2,
+			CIID:       3,
+		},
+	}
+	monitor := &nvmlDeviceHealthMonitor{
+		perGPUAllocatable: &PerGPUAllocatableDevices{
+			allocatablesMap: map[PCIBusID]AllocatableDevices{
+				parent.PciBusID: {
+					"static": staticMIG,
+				},
+			},
+		},
+		gpuInfosByUUID: map[string]*GpuDeviceInfo{parent.UUID: &GpuDeviceInfo{GpuInfo: parent}},
+	}
+
+	got, err := monitor.resolveDeviceByEventAddress(parent.UUID, nil, 2, 3)
+	require.NoError(t, err)
+	require.Equal(t, staticMIG, got)
+
+	got, err = monitor.resolveDeviceByEventAddress(parent.UUID, nil, FullGPUInstanceID, 3)
+	require.Nil(t, got)
+	require.NoError(t, err)
+
+	_, err = monitor.resolveDeviceByEventAddress("GPU-unknown", nil, 2, 3)
+	require.ErrorContains(t, err, "failed to find parent GPU UUID")
+
+}
+
+func TestAllocatableDevicesFindRejectsWrongParent(t *testing.T) {
+	parent := &GpuDeviceInfo{
+		GpuInfo: &nvidia.GpuInfo{
+			UUID:     "GPU-parent-1",
+			PciBusID: "0000:01:00.0",
+		},
+	}
+	otherParent := &GpuDeviceInfo{
+		GpuInfo: &nvidia.GpuInfo{
+			UUID:     "GPU-parent-2",
+			PciBusID: parent.PciBusID,
+		},
+	}
+
+	devices := AllocatableDevices{
+		"wrong-gpu": {
+			Gpu: otherParent,
+		},
+		"wrong-static-mig": {
+			MigStatic: &MigDeviceInfo{
+				ParentUUID: otherParent.UUID,
+				GIID:       2,
+				CIID:       3,
+				MigInfo: &nvidia.MigInfo{
+					Parent: otherParent.GpuInfo,
+				},
+			},
+		},
+	}
+
+	require.Nil(t, devices.GetGPUDeviceByUUID(parent.UUID))
+	require.Nil(t, devices.GetMigStaticDeviceByLiveTuple(&MigLiveTuple{
+		ParentUUID: parent.UUID,
+		GIID:       2,
+		CIID:       3,
+	}))
+}
+
+func TestHealthMonitorStartRequiresRegisteredEvents(t *testing.T) {
+	m := &nvmlDeviceHealthMonitor{}
+	require.ErrorContains(t, m.Start(context.Background()), "events have not been registered")
+}
+
+func TestClearDynamicMIGXIDTaint(t *testing.T) {
+	dynamic := &AllocatableDevice{MigDynamic: &MigSpec{}}
+	dynamic.AddOrUpdateTaint(&resourceapi.DeviceTaint{
+		Key:   TaintKeyXID,
+		Value: "43",
+	})
+	dynamic.AddOrUpdateTaint(&resourceapi.DeviceTaint{
+		Key: TaintKeyGPULost,
+	})
+
+	static := &AllocatableDevice{MigStatic: &MigDeviceInfo{}}
+	static.AddOrUpdateTaint(&resourceapi.DeviceTaint{
+		Key:   TaintKeyXID,
+		Value: "43",
+	})
+
+	state := &DeviceState{
+		perGPUAllocatable: &PerGPUAllocatableDevices{
+			allocatablesMap: map[PCIBusID]AllocatableDevices{
+				"0000:01:00.0": {
+					"dynamic": dynamic,
+					"static":  static,
+				},
+			},
+		},
+	}
+
+	state.clearDynamicMIGXIDTaint("dynamic")
+	state.clearDynamicMIGXIDTaint("static")
+
+	require.Len(t, dynamic.Taints(), 1)
+	assert.Equal(t, TaintKeyGPULost, dynamic.Taints()[0].Key)
+
+	require.Len(t, static.Taints(), 1)
+	assert.Equal(t, TaintKeyXID, static.Taints()[0].Key)
 }

--- a/pkg/kubeletplugin/device_state.go
+++ b/pkg/kubeletplugin/device_state.go
@@ -514,14 +514,18 @@ func (s *DeviceState) DestroyUnknownMIGDevices(ctx context.Context) {
 	klog.Infof("%s: done", logpfx)
 }
 
-func (s *DeviceState) Unprepare(ctx context.Context, claimRef kubeletplugin.NamespacedObject) error {
+// Unprepare returns true when cleanup removes a Dynamic MIG XID taint and the
+// caller must republish the ResourceSlice.
+// TODO: May be replace this bool with a general resource-change result if Unprepare
+// starts reporting other changes that require republishing.
+func (s *DeviceState) Unprepare(ctx context.Context, claimRef kubeletplugin.NamespacedObject) (bool, error) {
 	s.Lock()
 	defer s.Unlock()
 	klog.V(6).Infof("Unprepare() for claim '%s'", claimRef.String())
 
 	checkpoint, err := s.getCheckpoint(ctx)
 	if err != nil {
-		return fmt.Errorf("unable to get checkpoint: %w", err)
+		return false, fmt.Errorf("unable to get checkpoint: %v", err)
 	}
 
 	claimUID := string(claimRef.UID)
@@ -532,20 +536,22 @@ func (s *DeviceState) Unprepare(ctx context.Context, claimRef kubeletplugin.Name
 		// Prepare+Checkpoint are done transactionally). Note that
 		// claimRef.String() contains namespace, name, UID.
 		klog.V(2).Infof("Unprepare noop: claim not found in checkpoint data: %v", claimRef.String())
-		return nil
+		return false, nil
 	}
 
+	var taintRemoved bool
 	switch pc.CheckpointState {
 	case ClaimCheckpointStatePrepareStarted:
 		if err := s.unpreparePartiallyPreparedClaim(ctx, claimUID, pc, checkpoint); err != nil {
-			return fmt.Errorf("unprepare failed for partially prepared claim %s failed: %w", claimRef.String(), err)
+			return false, fmt.Errorf("unprepare failed for partially prepared claim %s failed: %w", claimRef.String(), err)
 		}
 	case ClaimCheckpointStatePrepareCompleted:
-		if err := s.unprepareDevices(ctx, claimRef, pc.PreparedDevices, checkpoint); err != nil {
-			return fmt.Errorf("unprepare devices failed for claim %s: %w", claimRef.String(), err)
+		taintRemoved, err = s.unprepareDevices(ctx, claimRef, pc.PreparedDevices, checkpoint)
+		if err != nil {
+			return false, fmt.Errorf("unprepare devices failed for claim %s: %w", claimRef.String(), err)
 		}
 	default:
-		return fmt.Errorf("unsupported ClaimCheckpointState: %v", pc.CheckpointState)
+		return false, fmt.Errorf("unsupported ClaimCheckpointState: %v", pc.CheckpointState)
 	}
 
 	// TODO: Remove this once partitionable device support is introduced for vfio devices.
@@ -580,13 +586,13 @@ func (s *DeviceState) Unprepare(ctx context.Context, claimRef kubeletplugin.Name
 			// back on the nvidia driver) with fresh Fabric Manager info.
 			err := s.discoverSiblingAllocatables(allocatableDevice)
 			if err != nil {
-				return fmt.Errorf("error discovering sibling allocatables: %w", err)
+				return false, fmt.Errorf("error discovering sibling allocatables: %w", err)
 			}
 		}
 	}
 	if s.fabricManagerPartitioningEnabled() {
 		if err := s.deactivateFabricPartition(claimUID, &pc, checkpoint); err != nil {
-			return fmt.Errorf("error deactivating fabric partition: %w", err)
+			return false, fmt.Errorf("error deactivating fabric partition: %w", err)
 		}
 	}
 
@@ -605,9 +611,9 @@ func (s *DeviceState) Unprepare(ctx context.Context, claimRef kubeletplugin.Name
 	// PreparedClaims map.
 	err = s.deleteClaimFromCheckpoint(ctx, claimRef)
 	if err != nil {
-		return fmt.Errorf("error deleting claim from checkpoint: %w", err)
+		return false, fmt.Errorf("error deleting claim from checkpoint: %w", err)
 	}
-	return nil
+	return taintRemoved, nil
 }
 
 // Rollback previously partially prepared claim.
@@ -1290,15 +1296,16 @@ func mergeContainerEdits(base *cdiapi.ContainerEdits, extra *cdiapi.ContainerEdi
 	return base.Append(extra)
 }
 
-func (s *DeviceState) unprepareDevices(ctx context.Context, claimRef kubeletplugin.NamespacedObject, devices PreparedDevices, checkpoint *Checkpoint) error {
+func (s *DeviceState) unprepareDevices(ctx context.Context, claimRef kubeletplugin.NamespacedObject, devices PreparedDevices, checkpoint *Checkpoint) (bool, error) {
 	klog.V(6).Infof("Unpreparing claim '%s', previously prepared devices from checkpoint: %v", claimRef.UID, devices.GetDeviceNames())
+	var taintRemoved bool
 	var vGpuDevices PreparedDeviceList
 	for _, group := range devices {
 		// Unconfigure the vfio-pci devices.
 		if featuregates.Enabled(featuregates.PassthroughSupport) {
 			err := s.unprepareVfioDevices(ctx, group.Devices.VfioDevices())
 			if err != nil {
-				return err
+				return false, err
 			}
 		}
 
@@ -1328,7 +1335,10 @@ func (s *DeviceState) unprepareDevices(ctx context.Context, claimRef kubeletplug
 					err := s.nvdevlib.deleteMigDevice(mig)
 					if err != nil {
 						klog.Warningf("Error deleting MIG device %s: %s", device.Mig.Device.DeviceName, err)
-						return fmt.Errorf("error deleting MIG device %s: %w", device.Mig.Device.DeviceName, err)
+						return false, fmt.Errorf("error deleting MIG device %s: %w", device.Mig.Device.DeviceName, err)
+					}
+					if s.clearDynamicMIGXIDTaint(device.Mig.Device.DeviceName) {
+						taintRemoved = true
 					}
 				} else {
 					klog.V(4).Infof("Unprepare: static MIG: noop (MIG %s)", device.Mig.Concrete.MigUUID)
@@ -1340,7 +1350,7 @@ func (s *DeviceState) unprepareDevices(ctx context.Context, claimRef kubeletplug
 		//if featuregates.Enabled(featuregates.MPSSupport) {
 		//	mpsControlDaemon := s.mpsManager.NewMpsControlDaemon(claimUID, group)
 		//	if err := mpsControlDaemon.Stop(ctx); err != nil {
-		//		return fmt.Errorf("error stopping MPS control daemon: %w", err)
+		//		return false, fmt.Errorf("error stopping MPS control daemon: %w", err)
 		//	}
 		//}
 
@@ -1363,7 +1373,7 @@ func (s *DeviceState) unprepareDevices(ctx context.Context, claimRef kubeletplug
 					if err == nvml.ERROR_NOT_SUPPORTED {
 						klog.Warningf("Unprepare: skip resetting time-slice policy for devices: %v", err)
 					} else {
-						return fmt.Errorf("error setting timeslice for devices: %w", err)
+						return false, fmt.Errorf("error setting timeslice for devices: %w", err)
 					}
 				}
 			}
@@ -1374,12 +1384,12 @@ func (s *DeviceState) unprepareDevices(ctx context.Context, claimRef kubeletplug
 	if featuregates.Enabled(featuregates.VGPUSupport) {
 		if len(vGpuDevices) > 0 {
 			if err := s.vgpuManager.Unprepare(claimRef, vGpuDevices); err != nil {
-				return fmt.Errorf("error cleanup vgpu devices: %w", err)
+				return false, fmt.Errorf("error cleanup vgpu devices: %w", err)
 			}
 		}
 	}
 
-	return nil
+	return taintRemoved, nil
 }
 
 // unprepareVfioDevices rebinds each passthrough GPU from vfio-pci back to the
@@ -2168,6 +2178,26 @@ func isAdminAccess(results []resourceapi.DeviceRequestAllocationResult) bool {
 		if r.AdminAccess != nil && *r.AdminAccess {
 			return true
 		}
+	}
+	return false
+}
+
+// clearDynamicMIGXIDTaint clears health state that belongs to a concrete
+// Dynamic MIG incarnation after that device no longer exists. Parent-scoped
+// taints, such as GPU lost or an unavailable health monitor, remain intact.
+//
+// NOTE: An XID event already queued before deletion could re-add the taint.
+// This cleanup intentionally does not track concrete MIG
+// incarnations; that race can be addressed separately if observed.
+func (s *DeviceState) clearDynamicMIGXIDTaint(name DeviceName) bool {
+	device := s.perGPUAllocatable.GetAllocatableDevice(name)
+	if device == nil || device.Type() != MigDynamicDeviceType {
+		return false
+	}
+	if taint, removed := device.RemoveTaint(TaintKeyXID); removed {
+		klog.V(4).Infof("Cleared health taint for destroyed Dynamic MIG device %s: key=%q, value=%q, effect=%s",
+			name, taint.Key, taint.Value, taint.Effect)
+		return true
 	}
 	return false
 }

--- a/pkg/kubeletplugin/driver.go
+++ b/pkg/kubeletplugin/driver.go
@@ -148,6 +148,24 @@ func NewDriver(ctx context.Context, config *Config) (*driver, error) {
 		useSplitResourceSlices: useSplitSlices,
 	}
 
+	// Register NVML events before kubeletplugin.Start exposes Prepare/Unprepare.
+	// On plugin restart, previously prepared devices and their workloads can remain
+	// live and emit an XID before the kubelet service is available. NVML does not
+	// retain events that occur before registration.
+	if featuregates.Enabled(featuregates.NVMLDeviceHealthCheck) {
+		deviceHealthMonitor, err := newNvmlDeviceHealthMonitor(config, state.perGPUAllocatable, state.nvdevlib)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create NVML device health monitor: %w", err)
+		}
+		driver.deviceHealthMonitor = deviceHealthMonitor
+
+		// Events recorded after registration remain queued until Start begins
+		// waiting after the kubelet helper is available.
+		if err := deviceHealthMonitor.RegisterEvents(); err != nil {
+			return nil, fmt.Errorf("failed to register NVML device events: %w", err)
+		}
+	}
+
 	opts := []kubeletplugin.Option{
 		kubeletplugin.KubeClient(driver.client),
 		kubeletplugin.NodeName(config.Flags.NodeName),
@@ -198,21 +216,6 @@ func NewDriver(ctx context.Context, config *Config) (*driver, error) {
 		})
 	}
 
-	if featuregates.Enabled(featuregates.NVMLDeviceHealthCheck) {
-		deviceHealthMonitor, err := newNvmlDeviceHealthMonitor(config, state.perGPUAllocatable, state.nvdevlib)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create NVML device health monitor: %w", err)
-		}
-		if err := deviceHealthMonitor.Start(ctx); err != nil {
-			return nil, fmt.Errorf("failed to start device health monitor: %w", err)
-		}
-		driver.deviceHealthMonitor = deviceHealthMonitor
-
-		driver.wg.Go(func() {
-			driver.deviceHealthEvents(ctx, config.Flags.NodeName, healthDeviceMap)
-		})
-	}
-
 	// The NRI cache is created before the gated blocks below so that, when both
 	// NRISupport and DevicePluginClientMode are enabled, the register server's
 	// pod-uid resolver and the NRI plugin share one cache instance (design
@@ -244,6 +247,23 @@ func NewDriver(ctx context.Context, config *Config) (*driver, error) {
 
 	if err := driver.publishResources(ctx, config); err != nil {
 		return nil, err
+	}
+
+	if featuregates.Enabled(featuregates.NVMLDeviceHealthCheck) {
+		// RegisterEvents can queue unmonitored events before this consumer
+		// starts. Publish the initial ResourceSlices first, so subsequent health
+		// updates republish tainted resources without an initial snapshot
+		// overwriting them.
+		// TODO: NVML does not replay XIDs emitted before registration. Because
+		// health taints are not persisted, a restart can advertise a device as
+		// healthy unless the fault emits another event. Persist health state or
+		// validate recovery before clearing taints during startup.
+		driver.wg.Go(func() {
+			driver.deviceHealthEvents(ctx, healthDeviceMap)
+		})
+		if err := driver.deviceHealthMonitor.Start(ctx); err != nil {
+			return nil, fmt.Errorf("failed to start device health monitor: %w", err)
+		}
 	}
 
 	klog.V(4).Infof("Current kubelet plugin registration status: %s", helper.RegistrationStatus())
@@ -525,7 +545,7 @@ func (d *driver) nodeUnprepareResource(ctx context.Context, claimRef kubeletplug
 
 	cs := claimRef.String()
 	tunprep0 := time.Now()
-	err = d.state.Unprepare(ctx, claimRef)
+	taintRemovedRepublish, err := d.state.Unprepare(ctx, claimRef)
 	klog.V(6).Infof("t_unprep %.3f s (claim %s)", time.Since(tunprep0).Seconds(), cs)
 
 	if err != nil {
@@ -533,8 +553,12 @@ func (d *driver) nodeUnprepareResource(ctx context.Context, claimRef kubeletplug
 		return fmt.Errorf("error unpreparing devices for claim %v: %w", claimRef.String(), err)
 	}
 
-	if featuregates.Enabled(featuregates.PassthroughSupport) {
-		// Re-advertise updated resourceslice after unpreparing devices.
+	if featuregates.Enabled(featuregates.PassthroughSupport) ||
+		(featuregates.Enabled(featuregates.DynamicMIG) &&
+			featuregates.Enabled(featuregates.NVMLDeviceHealthCheck) &&
+			taintRemovedRepublish) {
+		// Re-advertise updated resourceslice after unpreparing devices
+		// or removed a Dynamic MIG XID taint.
 		if err = d.publishResources(ctx, d.state.config); err != nil {
 			drametrics.IncNodeUnprepareError(util.DRADriverName, "publish_resources")
 			return fmt.Errorf("error publishing resources: %w", err)
@@ -594,7 +618,7 @@ func IsHealthy(taints []resourceapi.DeviceTaint) bool {
 	return true
 }
 
-func (d *driver) deviceHealthEvents(ctx context.Context, nodeName string, healthDeviceMap map[string]*manager.GPUDevice) {
+func (d *driver) deviceHealthEvents(ctx context.Context, healthDeviceMap map[string]*manager.GPUDevice) {
 	klog.V(4).Info("Starting to watch for device health notifications")
 	for {
 		select {
@@ -611,29 +635,16 @@ func (d *driver) deviceHealthEvents(ctx context.Context, nodeName string, health
 			taint := healthEventToTaint(d.deviceHealthMonitor, event)
 			modified := false
 			for _, dev := range event.Devices {
-				klog.Warningf("Received %s health event for device %s", event.EventType, dev.UUID())
+				klog.Warningf("Received %s health event for device %s", event.EventType, dev.CanonicalName())
 				if d.state.AddDeviceTaint(dev, taint) {
 					modified = true
+					if device, ok := healthDeviceMap[dev.CanonicalName()]; ok {
+						device.Healthy = IsHealthy(dev.Taints())
+					}
 				}
 			}
 			if !modified {
 				continue
-			}
-
-			var resourceSlice resourceslice.Slice
-			for _, devices := range d.state.perGPUAllocatable.allocatablesMap {
-				for _, dev := range devices {
-					d := dev.GetDevice(d.state.config)
-
-					taints := dev.Taints()
-					if len(taints) > 0 {
-						d.Taints = taints
-					}
-					if device, ok := healthDeviceMap[dev.CanonicalName()]; ok {
-						device.Healthy = IsHealthy(d.Taints)
-					}
-					resourceSlice.Devices = append(resourceSlice.Devices, d)
-				}
 			}
 
 			// NOTE: We only log an error on publish failure and do not retry.
@@ -650,12 +661,6 @@ func (d *driver) deviceHealthEvents(ctx context.Context, nodeName string, health
 			klog.V(4).Infof("Republishing ResourceSlice: %d device(s) tainted with %s=%q (effect=%s)",
 				len(event.Devices), taint.Key, taint.Value, taint.Effect)
 
-			resources := resourceslice.DriverResources{
-				Pools: map[string]resourceslice.Pool{
-					nodeName: {Slices: []resourceslice.Slice{resourceSlice}},
-				},
-			}
-
 			// NOTE: GPU_LOST and unmonitored events are already batched at the
 			// sender (all affected devices arrive in a single DeviceHealthEvent).
 			// XID events are still per-device and may cause repeated publishes.
@@ -663,8 +668,8 @@ func (d *driver) deviceHealthEvents(ctx context.Context, nodeName string, health
 			// Evaluate two strategies:
 			// 1. Channel drain: non-blocking pull of all pending events (Pro: zero latency; Con: susceptible to NVML lag).
 			// 2. Timer debounce: e.g., 50ms window (Pro: standard K8s API protection; Con: slight delay).
-			// This also needs to be handle properly in the recovery path.
-			if err := d.pluginhelper.PublishResources(ctx, resources); err != nil {
+			// This also needs to be handled properly in the recovery path.
+			if err := d.publishResources(ctx, d.state.config); err != nil {
 				klog.Errorf("Failed to publish resources after taint update: %v", err)
 			}
 		}

--- a/pkg/kubeletplugin/featuregates/featuregates.go
+++ b/pkg/kubeletplugin/featuregates/featuregates.go
@@ -322,10 +322,6 @@ func ValidateFeatureGates() error {
 		return fmt.Errorf("feature gate %s is currently mutually exclusive with %s", DynamicMIG, PassthroughSupport)
 	}
 
-	if Enabled(DynamicMIG) && Enabled(NVMLDeviceHealthCheck) {
-		return fmt.Errorf("feature gate %s is currently mutually exclusive with %s", DynamicMIG, NVMLDeviceHealthCheck)
-	}
-
 	if Enabled(DynamicMIG) && Enabled(MPSSupport) {
 		return fmt.Errorf("feature gate %s is currently mutually exclusive with %s", DynamicMIG, MPSSupport)
 	}

--- a/pkg/kubeletplugin/featuregates/featuregates_test.go
+++ b/pkg/kubeletplugin/featuregates/featuregates_test.go
@@ -471,11 +471,10 @@ func TestValidateFeatureGates(t *testing.T) {
 			description:  "should fail when both DynamicMIG and PassthroughSupport are enabled",
 		},
 		{
-			name:         "DynamicMIG enabled with NVMLDeviceHealthCheck",
-			fgMap:        map[featuregate.Feature]bool{VGPUSupport: false, DynamicMIG: true, NVMLDeviceHealthCheck: true},
-			expectError:  true,
-			errorMessage: "feature gate DynamicMIG is currently mutually exclusive with NVMLDeviceHealthCheck",
-			description:  "should fail when both DynamicMIG and NVMLDeviceHealthCheck are enabled",
+			name:        "DynamicMIG enabled with NVMLDeviceHealthCheck",
+			fgMap:       map[featuregate.Feature]bool{VGPUSupport: false, DynamicMIG: true, NVMLDeviceHealthCheck: true},
+			expectError: false,
+			description: "should allow DynamicMIG health monitoring",
 		},
 		{
 			name:         "DynamicMIG enabled with MPSSupport",

--- a/pkg/kubeletplugin/partitions.go
+++ b/pkg/kubeletplugin/partitions.go
@@ -238,24 +238,25 @@ func (i MigSpec) PartConsumesCounters() []resourceapi.DeviceCounterConsumption {
 
 // A variant of the legacy `GetDevice()`, for the Partitionable Devices paradigm.
 func (d *AllocatableDevice) PartGetDevice(config *Config) resourceapi.Device {
+	var dev resourceapi.Device
 	switch d.Type() {
 	case VGpuDeviceType:
-		return d.VGpu.PartGetDevice()
+		dev = d.VGpu.PartGetDevice()
 	case GpuDeviceType:
-		dev := d.Gpu.PartGetDevice()
+		dev = d.Gpu.PartGetDevice()
 		applyConsumableShares(&dev, config)
-		return dev
 	case MigStaticDeviceType:
 		panic("PartGetDevice() called for MigStaticDeviceType")
 	case MigDynamicDeviceType:
-		dev := d.MigDynamic.PartGetDevice()
+		dev = d.MigDynamic.PartGetDevice()
 		applyConsumableShares(&dev, config)
-		return dev
 	case VfioDeviceType:
 		panic("not yet implemented")
 	default:
 		panic("unexpected type for AllocatableDevice")
 	}
+	dev.Taints = d.Taints()
+	return dev
 }
 
 // Insert one counter for each memory slice consumed, as given by the `start`

--- a/pkg/util/consts.go
+++ b/pkg/util/consts.go
@@ -28,6 +28,8 @@ const (
 	NvidiaDomain                 = "nvidia.com"
 	NodeNvidiaDriverVersionLabel = NvidiaDomain + "/node-driver-version"
 	NodeNvidiaCudaVersionLabel   = NvidiaDomain + "/node-cuda-version"
+	NodeNvidiaCudaMajorLabel     = NvidiaDomain + "/node-cuda-major"
+	NodeNvidiaCudaMinorLabel     = NvidiaDomain + "/node-cuda-minor"
 	NvidiaNativeGPUResourceName  = NvidiaDomain + "/gpu"
 
 	DRADriverName       = "manager.nvidia.com"

--- a/versions.mk
+++ b/versions.mk
@@ -36,7 +36,7 @@ GOLANG_VERSION := $(shell grep -E '^go [0-9]' go.mod | grep -oE '[0-9][0-9.]*')
 TOOLKIT_CONTAINER_IMAGE := $(shell chmod +x ./scripts/toolkit-container-image.sh && ./scripts/toolkit-container-image.sh)
 
 # nvVersion represents the version of dra-driver-nvidia-gpu that this project is based on
-NVVERSION := v0.4.1
+NVVERSION := v0.5.0
 
 print-%:
 	@echo $($*)


### PR DESCRIPTION
Driver symbols now resolve to our hooks whatever the dlsym handle says. RTLD_NEXT used to be forwarded straight to the driver, which was a one-line way around the limits.

- Drop the RTLD_NEXT lookup history table: it returned NULL whenever a thread resolved the same pointer twice, mistaking repetition for recursion.
- Match cu[A-Z]* / cudbg* / nvml[A-Z]* like the version script does, so cuBLAS / cuDNN / curl_* no longer take the hook lookup path.
- Bootstrap real_dlsym with dlvsym: the old fallback called the public dlsym, which resolved back into our own hook and could never succeed.
- Add a build check forbidding public dlsym calls in src/, and build with -fno-semantic-interposition.